### PR TITLE
Change public exports shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Dependencies: _none_.
 ### tabbable
 
 ```js
-import tabbable from 'tabbable';
+import { tabbable } from 'tabbable';
 
 tabbable(rootNode, [options]);
 ```

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ npm install tabbable
 
 Dependencies: _none_.
 
-You'll need to be compiling CommonJS with your bundler of choice.
-
 ## API
 
 ### tabbable
 
-```
-tabbable(rootNode, [options])
+```js
+import tabbable from 'tabbable';
+
+tabbable(rootNode, [options]);
 ```
 
 Returns an array of ordered tabbable node within the `rootNode`.
@@ -76,18 +76,22 @@ Type: `boolean`. Default: `false`.
 
 If set to `true`, `rootNode` will be included in the returned tabbable node array, if `rootNode` is tabbable.
 
-### tabbable.isTabbable
+### isTabbable
 
-```
-tabbable.isTabbable(node)
+```js
+import { isTabbable } from 'tabbable';
+
+isTabbable(node);
 ```
 
 Returns a boolean indicating whether the provided node is considered tabbable.
 
-### tabbable.isFocusable
+### isFocusable
 
-```
-tabbable.isFocusable(node)
+```js
+import { isFocusable } from 'tabbable';
+
+isFocusable(node);
 ```
 
 Returns a boolean indicating whether the provided node is considered _focusable_.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,7 +36,6 @@ const cjs = [
       format: 'cjs',
       esModule: false,
       sourcemap: true,
-      exports: 'named',
     },
   },
   {
@@ -46,7 +45,6 @@ const cjs = [
       format: 'cjs',
       esModule: false,
       sourcemap: true,
-      exports: 'named',
     },
     plugins: [...commonPlugins, terser({ ...terserOptions, toplevel: true })],
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,6 +36,7 @@ const cjs = [
       format: 'cjs',
       esModule: false,
       sourcemap: true,
+      exports: 'named',
     },
   },
   {
@@ -45,6 +46,7 @@ const cjs = [
       format: 'cjs',
       esModule: false,
       sourcemap: true,
+      exports: 'named',
     },
     plugins: [...commonPlugins, terser({ ...terserOptions, toplevel: true })],
   },

--- a/src/index.js
+++ b/src/index.js
@@ -62,9 +62,6 @@ function tabbable(el, options) {
   return tabbableNodes;
 }
 
-tabbable.isTabbable = isTabbable;
-tabbable.isFocusable = isFocusable;
-
 function isNodeMatchingSelectorTabbable(node) {
   if (
     !isNodeMatchingSelectorFocusable(node) ||
@@ -173,3 +170,4 @@ function isHidden(node) {
 }
 
 export default tabbable;
+export { isTabbable, isFocusable };

--- a/src/index.js
+++ b/src/index.js
@@ -169,5 +169,4 @@ function isHidden(node) {
   );
 }
 
-export default tabbable;
-export { isTabbable, isFocusable };
+export { tabbable, isTabbable, isFocusable };

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -1,5 +1,6 @@
 const assert = require('chai').assert;
-const tabbable = require('../dist/index.min.js');
+const tabbable = require('../dist/index.min.js').default;
+const { isFocusable, isTabbable } = require('../dist/index.min.js');
 const fixtures = require('./fixtures');
 
 let fixtureRoots = [];
@@ -219,80 +220,80 @@ describe('tabbable', () => {
         assert.deepEqual(actual, expected);
       });
 
-      it('tabbable.isTabbable', () => {
+      it('isTabbable', () => {
         let n1 = assertionSet
           .getFixture('basic')
           .getDocument()
           .getElementById('contenteditable-true');
-        assert.ok(tabbable.isTabbable(n1));
+        assert.ok(isTabbable(n1));
         let n2 = assertionSet
           .getFixture('basic')
           .getDocument()
           .getElementById('contenteditable-false');
-        assert.notOk(tabbable.isTabbable(n2));
+        assert.notOk(isTabbable(n2));
         let n3 = assertionSet
           .getFixture('basic')
           .getDocument()
           .getElementById('href-anchor');
-        assert.ok(tabbable.isTabbable(n3));
+        assert.ok(isTabbable(n3));
         let n4 = assertionSet
           .getFixture('basic')
           .getDocument()
           .getElementById('hrefless-anchor');
-        assert.notOk(tabbable.isTabbable(n4));
+        assert.notOk(isTabbable(n4));
         let n5 = assertionSet
           .getFixture('basic')
           .getDocument()
           .getElementById('iframe');
-        assert.notOk(tabbable.isTabbable(n5));
+        assert.notOk(isTabbable(n5));
         let n6 = assertionSet
           .getFixture('radio')
           .getDocument()
           .getElementById('radio-a');
-        assert.ok(tabbable.isTabbable(n6));
+        assert.ok(isTabbable(n6));
         let n7 = assertionSet
           .getFixture('radio')
           .getDocument()
           .getElementById('radio-c');
-        assert.notOk(tabbable.isTabbable(n7));
+        assert.notOk(isTabbable(n7));
       });
 
-      it('tabbable.isFocusable', () => {
+      it('isFocusable', () => {
         let n1 = assertionSet
           .getFixture('basic')
           .getDocument()
           .getElementById('contenteditable-true');
-        assert.ok(tabbable.isFocusable(n1));
+        assert.ok(isFocusable(n1));
         let n2 = assertionSet
           .getFixture('basic')
           .getDocument()
           .getElementById('contenteditable-false');
-        assert.notOk(tabbable.isFocusable(n2));
+        assert.notOk(isFocusable(n2));
         let n3 = assertionSet
           .getFixture('basic')
           .getDocument()
           .getElementById('href-anchor');
-        assert.ok(tabbable.isFocusable(n3));
+        assert.ok(isFocusable(n3));
         let n4 = assertionSet
           .getFixture('basic')
           .getDocument()
           .getElementById('hrefless-anchor');
-        assert.notOk(tabbable.isFocusable(n4));
+        assert.notOk(isFocusable(n4));
         let n5 = assertionSet
           .getFixture('basic')
           .getDocument()
           .getElementById('iframe');
-        assert.ok(tabbable.isFocusable(n5));
+        assert.ok(isFocusable(n5));
         let n6 = assertionSet
           .getFixture('radio')
           .getDocument()
           .getElementById('radio-a');
-        assert.ok(tabbable.isFocusable(n6));
+        assert.ok(isFocusable(n6));
         let n7 = assertionSet
           .getFixture('radio')
           .getDocument()
           .getElementById('radio-c');
-        assert.ok(tabbable.isFocusable(n7));
+        assert.ok(isFocusable(n7));
       });
 
       it('supports elements in a shadow root', () => {

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -1,6 +1,5 @@
 const assert = require('chai').assert;
-const tabbable = require('../dist/index.min.js').default;
-const { isFocusable, isTabbable } = require('../dist/index.min.js');
+const { tabbable, isFocusable, isTabbable } = require('../dist/index.min.js');
 
 const fixtures = require('./fixtures');
 


### PR DESCRIPTION
**Why?**

Improving tree-shakeability of this package. Usage of static properties like this usually retains the containing object (in this case a function) even if it stays unused. This matters when `tabbable` is being used as transitive dep.

Partially fixes #39 

⚠️ this is a breaking change