### PR TITLE
The TypeScript return type of `tabbable` has been changed from `Array<Element>` to `Array<HTMLElement | SVGElement>`

### DIFF
--- a/.changeset/blue-lions-wink.md
+++ b/.changeset/blue-lions-wink.md
@@ -1,5 +1,5 @@
 ---
-'tabbable': minor
+'tabbable': patch
 ---
 
-The TypeScript return type of `tabbable` has been changed from `Array<Element>` to `Array<HTMLElement | SVGElement>`.
+The TypeScript return type of `tabbable` has been fixed: Was `Array<Element>` (an `Element` is technically not focusable), is now `Array<HTMLElement | SVGElement>` (which are both still/also `Element` instances).

--- a/.changeset/blue-lions-wink.md
+++ b/.changeset/blue-lions-wink.md
@@ -1,0 +1,5 @@
+---
+'tabbable': minor
+---
+
+The TypeScript return type of `tabbable` has been changed from `Array<Element>` to `Array<HTMLElement | SVGElement>`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+type FocusableElement = HTMLElement | SVGElement;
+
 export type TabbableOptions = {
   includeContainer?: boolean;
 };
@@ -5,12 +7,12 @@ export type TabbableOptions = {
 export declare function tabbable(
   container: Element,
   options?: TabbableOptions
-): Element[];
+): FocusableElement[];
 
 export declare function focusable(
   container: Element,
   options?: TabbableOptions
-): Element[];
+): FocusableElement[];
 
 export declare function isTabbable(element: Element): boolean;
 


### PR DESCRIPTION
Please verify this but I believe that the change is correct - it seems that the raw `Element` interface doesn't have `focus()` method on it. That method comes from `HTMLOrSVGElement` which both `HTMLElement` and `SVGElement` extend.

###  Features and Bug Fixes

- [x] Typings added/updated.
- [x] Changeset added (run `yarn changeset` locally to add one, follow prompts).