### PR TITLE
Transpile non-minified bundles

### DIFF
--- a/.changeset/proud-nails-smoke.md
+++ b/.changeset/proud-nails-smoke.md
@@ -1,0 +1,5 @@
+---
+'tabbable': patch
+---
+
+Fix #96: Transpile non-minified bundles for expected browser targets.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,17 +1,44 @@
 /* eslint-env node */
 
+const plugins = [
+  '@babel/plugin-proposal-nullish-coalescing-operator',
+  '@babel/plugin-proposal-optional-chaining',
+];
+
 module.exports = {
-  presets: [
-    [
-      '@babel/preset-env',
-      {
-        modules: false,
-        loose: true,
-      },
-    ],
-  ],
-  plugins: [
-    '@babel/plugin-proposal-nullish-coalescing-operator',
-    '@babel/plugin-proposal-optional-chaining',
-  ],
+  env: {
+    es5: {
+      // ES5 browsers for CJS and UMD builds
+      presets: [
+        [
+          // NOTE: With no targets specified, @babel/preset-env will transform all
+          //  ECMAScript 2015+ code by default, which is the original preset prior
+          //  to upgrading to Babel 7
+          // @see https://babeljs.io/docs/en/babel-preset-env#targets
+          '@babel/preset-env',
+          {
+            loose: true,
+          },
+        ],
+      ],
+      plugins,
+    },
+    esm: {
+      // ESM browsers for ESM builds
+      presets: [
+        [
+          // @see https://babeljs.io/docs/en/babel-preset-env#targets
+          '@babel/preset-env',
+          {
+            modules: false, // preserve ES modules
+            loose: true,
+            targets: {
+              esmodules: true,
+            },
+          },
+        ],
+      ],
+      plugins,
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "scripts": {
     "build": "yarn clean && yarn compile",
     "clean": "rm -rf ./dist",
-    "compile-esm": "cross-env BUILD_ENV=esm rollup -c",
-    "compile-cjs": "cross-env BUILD_ENV=cjs rollup -c",
-    "compile-umd": "cross-env BUILD_ENV=umd rollup -c",
+    "compile-esm": "cross-env BUILD_ENV=esm BABEL_ENV=esm rollup -c",
+    "compile-cjs": "cross-env BUILD_ENV=cjs BABEL_ENV=es5 rollup -c",
+    "compile-umd": "cross-env BUILD_ENV=umd BABEL_ENV=es5 rollup -c",
     "compile": "yarn compile-esm && yarn compile-cjs && yarn compile-umd",
     "format": "prettier --write \"{*,src/**/*,test/**/*,.github/workflows/*}.+(js|yml)\"",
     "format-check": "prettier --check \"{*,src/**/*,test/**/*,.github/workflows/*}.+(js|yml)\"",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -71,6 +71,7 @@ const cjs = [
       format: 'cjs',
       ...commonOutput,
     },
+    plugins: commonPlugins,
   },
   {
     ...commonConfig,
@@ -93,6 +94,7 @@ const esm = [
       format: 'esm',
       ...commonOutput,
     },
+    plugins: commonPlugins,
   },
   {
     ...commonConfig,
@@ -118,6 +120,7 @@ const umd = [
       ...commonOutput,
       globals: {},
     },
+    plugins: commonPlugins,
   },
   {
     ...commonConfig,


### PR DESCRIPTION
Fixes #96

Also targets ESM browsers for the ESM build, rather than ES5 browsers
for the other builds.

###  Features and Bug Fixes

- [x] Issue being fixed is referenced.
- [x] ~Test coverage added/updated.~
- [x] ~Typings added/updated.~
- [x] ~README updated (API changes, instructions, etc.).~
- [x] ~Changes to dependencies explained.~
- [x] Changeset added (run `yarn changeset` locally to add one, follow prompts).
