### PR TITLE
fix: use a traditional function expression for old browsers

### DIFF
--- a/.changeset/lemon-birds-watch.md
+++ b/.changeset/lemon-birds-watch.md
@@ -1,0 +1,5 @@
+---
+'tabbable': patch
+---
+
+fix: remove arrow function and use tradional function expression for older browser support

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,9 @@ function tabbable(el, options) {
 
   let tabbableNodes = orderedTabbables
     .sort(sortOrderedTabbables)
-    .map((a) => a.node)
+    .map(function (a) {
+      return a.node;
+    })
     .concat(regularTabbables);
 
   return tabbableNodes;


### PR DESCRIPTION
Issue https://github.com/focus-trap/tabbable/issues/99

An arrow function is causing syntax errors in ie11

This is not the best solution but it's the fastest, please close if you don't like it,
a better long term solution would be to make sure that babel is correctly configured 
I have made a pull request here https://github.com/focus-trap/tabbable/pull/103

###  Features and Bug Fixes

- [X] Issue being fixed is referenced.
~~[ ] Test coverage added/updated.~~
~~[ ] Typings added/updated.~~
~~[ ] README updated (API changes, instructions, etc.).~~
~~[ ] Changes to dependencies explained.~~
- [X] Changeset added (run `yarn changeset` locally to add one, follow prompts).
