### PR TITLE
fix: remove arrow function causing issues for old browsers using a babel

### DIFF
--- a/.changeset/afraid-trees-brush.md
+++ b/.changeset/afraid-trees-brush.md
@@ -1,0 +1,5 @@
+---
+'tabbable': patch
+---
+
+fix: remove arrow function causing issues for old browsers

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,6 +3,7 @@
 const plugins = [
   '@babel/plugin-proposal-nullish-coalescing-operator',
   '@babel/plugin-proposal-optional-chaining',
+  '@babel/plugin-transform-arrow-functions',
 ];
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@babel/core": "^7.11.6",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
     "@babel/plugin-proposal-optional-chaining": "^7.11.0",
+    "@babel/plugin-transform-arrow-functions": "^7.10.4",
     "@babel/preset-env": "^7.11.5",
     "@changesets/cli": "^2.10.3",
     "@rollup/plugin-babel": "^5.2.1",


### PR DESCRIPTION
Issue https://github.com/focus-trap/tabbable/issues/99

An arrow function is causing syntax errors in ie11
I have added a babel plugin to transform arrow functions

###  Features and Bug Fixes

- [x] Issue being fixed is referenced.
~~[ ] Test coverage added/updated.~~
~~[ ] Typings added/updated.~~
~~[ ] README updated (API changes, instructions, etc.).~~
- [x] Changes to dependencies explained.
- [x] Changeset added (run `yarn changeset` locally to add one, follow prompts).

