### PR TITLE
Details and summary element fixes

### DIFF
--- a/.changeset/healthy-ravens-pump.md
+++ b/.changeset/healthy-ravens-pump.md
@@ -1,0 +1,5 @@
+---
+'tabbable': patch
+---
+
+ignore elements nested under a closed details element + any extra summary elements

--- a/.changeset/healthy-ravens-pump.md
+++ b/.changeset/healthy-ravens-pump.md
@@ -2,4 +2,6 @@
 'tabbable': patch
 ---
 
-ignore elements nested under a closed details element + any extra summary elements
+- ignore elements nested under a closed details element
+- ignore any extra summary elements after the first summary element
+- add details element as tabbable in case it has no direct summary element

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following are considered tabbable:
 - `<textarea>` elements
 - `<a>` elements with `href` or `xlink:href` attributes
 - `<audio>` and `<videos>` elements with `controls` attributes
-- `<summary>` element directly under a `<details>` element
+- the first `<summary>` element directly under a `<details>` element
 - elements with the `[contenteditable]` attribute
 - anything with a non-negative `tabindex` attribute
 
@@ -25,6 +25,7 @@ Any of the above will _not_ be considered tabbable, though, if any of the follow
 - has a negative `tabindex` attribute
 - has a `disabled` attribute
 - either the node itself _or an ancestor of it_ is hidden via `display: none` or `visibility: hidden`
+- is nested under a closed `<detailed>` element (with the exception of the first `<summary>` element)
 - is an `<input type="radio">` element and a different radio in its group is `checked`
 
 **If you think a node should be included in your array of tabbables _but it's not_, all you need to do is add `tabindex="0"` to deliberately include it.** (Or if it is in your array but you don't want it, you can add `tabindex="-1"` to deliberately exclude it.) This will also result in more consistent cross-browser behavior. For information about why your special node might _not_ be included, see ["More details"](#more-details), below.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The following are considered tabbable:
 - `<a>` elements with `href` or `xlink:href` attributes
 - `<audio>` and `<videos>` elements with `controls` attributes
 - the first `<summary>` element directly under a `<details>` element
+- `<details>` element without a `<summary>` element
 - elements with the `[contenteditable]` attribute
 - anything with a non-negative `tabindex` attribute
 
@@ -25,7 +26,7 @@ Any of the above will _not_ be considered tabbable, though, if any of the follow
 - has a negative `tabindex` attribute
 - has a `disabled` attribute
 - either the node itself _or an ancestor of it_ is hidden via `display: none` or `visibility: hidden`
-- is nested under a closed `<detailed>` element (with the exception of the first `<summary>` element)
+- is nested under a closed `<details>` element (with the exception of the first `<summary>` element)
 - is an `<input type="radio">` element and a different radio in its group is `checked`
 
 **If you think a node should be included in your array of tabbables _but it's not_, all you need to do is add `tabindex="0"` to deliberately include it.** (Or if it is in your array but you don't want it, you can add `tabindex="-1"` to deliberately exclude it.) This will also result in more consistent cross-browser behavior. For information about why your special node might _not_ be included, see ["More details"](#more-details), below.

--- a/src/index.js
+++ b/src/index.js
@@ -193,6 +193,12 @@ function isTabbableRadio(node) {
 function isHidden(node) {
   if (getComputedStyle(node).visibility === 'hidden') return true;
 
+  const isDirectSummary = node.matches('details>summary:first-of-type');
+  const nodeUnderDetails = isDirectSummary ? node.parentElement : node;
+  if (nodeUnderDetails.matches('details:not([open]) *')) {
+    return true;
+  }
+
   while (node) {
     if (getComputedStyle(node).display === 'none') return true;
     node = node.parentElement;

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,8 @@ function isNodeMatchingSelectorFocusable(node) {
     node.disabled ||
     isHiddenInput(node) ||
     isHidden(node) ||
-    isDetailsWithSummary(node)
+    /* For a details element with a summary, the summary element gets the focused  */
+    isDetailsWithSummary(node) 
   ) {
     return false;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ let candidateSelectors = [
   'audio[controls]',
   'video[controls]',
   '[contenteditable]:not([contenteditable="false"])',
-  'details>summary',
+  'details>summary:first-of-type',
 ];
 let candidateSelector = /* #__PURE__ */ candidateSelectors.join(',');
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ let candidateSelectors = [
   'video[controls]',
   '[contenteditable]:not([contenteditable="false"])',
   'details>summary:first-of-type',
+  'details',
 ];
 let candidateSelector = /* #__PURE__ */ candidateSelectors.join(',');
 
@@ -97,7 +98,12 @@ function isTabbable(node) {
 }
 
 function isNodeMatchingSelectorFocusable(node) {
-  if (node.disabled || isHiddenInput(node) || isHidden(node)) {
+  if (
+    node.disabled ||
+    isHiddenInput(node) ||
+    isHidden(node) ||
+    isDetailsWithSummary(node)
+  ) {
     return false;
   }
   return true;
@@ -129,13 +135,15 @@ function getTabindex(node) {
     return 0;
   }
 
-  // in Chrome, <audio controls/> and <video controls/> elements get a default
+  // in Chrome, <details/>, <audio controls/> and <video controls/> elements get a default
   //  `tabIndex` of -1 when the 'tabindex' attribute isn't specified in the DOM,
   //  yet they are still part of the regular tab order; in FF, they get a default
   //  `tabIndex` of 0; since Chrome still puts those elements in the regular tab
-  //  order, consider their tab index to be 0
+  //  order, consider their tab index to be 0.
   if (
-    (node.nodeName === 'AUDIO' || node.nodeName === 'VIDEO') &&
+    (node.nodeName === 'AUDIO' ||
+      node.nodeName === 'VIDEO' ||
+      node.nodeName === 'DETAILS') &&
     node.getAttribute('tabindex') === null
   ) {
     return 0;
@@ -160,6 +168,15 @@ function isInput(node) {
 
 function isHiddenInput(node) {
   return isInput(node) && node.type === 'hidden';
+}
+
+function isDetailsWithSummary(node) {
+  const r =
+    node.tagName === 'DETAILS' &&
+    Array.prototype.slice
+      .apply(node.children)
+      .some((child) => child.tagName === 'SUMMARY');
+  return r;
 }
 
 function isRadio(node) {

--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,7 @@ function isNodeMatchingSelectorFocusable(node) {
     isHiddenInput(node) ||
     isHidden(node) ||
     /* For a details element with a summary, the summary element gets the focused  */
-    isDetailsWithSummary(node) 
+    isDetailsWithSummary(node)
   ) {
     return false;
   }

--- a/test/fixtures/details.html
+++ b/test/fixtures/details.html
@@ -1,11 +1,14 @@
-<details>
+<details id="details-a">
   <summary id="details-a-summary">details A title</summary>
   details A content
   <input id="hidden-input"></input>
 </details>
-<details open>
+<details open id="details-b">
   <summary id="details-b-summary">details B title</summary>
   <summary id="details-b-ignored-summary">ignored summary</summary>
   details B content
   <input id="visible-input"></input>
+</details>
+<details id="details-c">
+  content...
 </details>

--- a/test/fixtures/details.html
+++ b/test/fixtures/details.html
@@ -1,8 +1,10 @@
 <details>
   <summary id="details-a-summery">details A title</summary>
   details A content
+  <input id="hidden-input"></input>
 </details>
-<details>
+<details open>
   <summary id="details-b-summery">details B title</summary>
   details B content
+  <input id="visible-input"></input>
 </details>

--- a/test/fixtures/details.html
+++ b/test/fixtures/details.html
@@ -5,6 +5,7 @@
 </details>
 <details open>
   <summary id="details-b-summery">details B title</summary>
+  <summary id="details-b-ignored-summery">ignored summary</summary>
   details B content
   <input id="visible-input"></input>
 </details>

--- a/test/fixtures/details.html
+++ b/test/fixtures/details.html
@@ -1,11 +1,11 @@
 <details>
-  <summary id="details-a-summery">details A title</summary>
+  <summary id="details-a-summary">details A title</summary>
   details A content
   <input id="hidden-input"></input>
 </details>
 <details open>
-  <summary id="details-b-summery">details B title</summary>
-  <summary id="details-b-ignored-summery">ignored summary</summary>
+  <summary id="details-b-summary">details B title</summary>
+  <summary id="details-b-ignored-summary">ignored summary</summary>
   details B content
   <input id="visible-input"></input>
 </details>

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -243,7 +243,7 @@ describe('tabbable', () => {
 
         it('details', () => {
           let actual = assertionSet.getFixture('details').getTabbableIds();
-          let expected = ['details-a-summery', 'details-b-summery', 'visible-input'];
+          let expected = ['details-a-summary', 'details-b-summary', 'visible-input'];
           assert.deepEqual(actual, expected);
         });
 
@@ -408,7 +408,7 @@ describe('tabbable', () => {
 
         it('details', () => {
           let actual = assertionSet.getFixture('details').getFocusableIds();
-          let expected = ['details-a-summery', 'details-b-summery', 'visible-input'];
+          let expected = ['details-a-summary', 'details-b-summary', 'visible-input'];
           assert.deepEqual(actual.sort(), expected.sort());
         });
 
@@ -468,7 +468,7 @@ describe('tabbable', () => {
           let n8 = assertionSet
             .getFixture('details')
             .getDocument()
-            .getElementById('details-a-summery');
+            .getElementById('details-a-summary');
           assert.ok(isTabbable(n8));
         });
       });
@@ -513,7 +513,7 @@ describe('tabbable', () => {
           let n8 = assertionSet
             .getFixture('details')
             .getDocument()
-            .getElementById('details-a-summery');
+            .getElementById('details-a-summary');
           assert.ok(isFocusable(n8));
         });
       });

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -243,7 +243,11 @@ describe('tabbable', () => {
 
         it('details', () => {
           let actual = assertionSet.getFixture('details').getTabbableIds();
-          let expected = ['details-a-summary', 'details-b-summary', 'visible-input'];
+          let expected = [
+            'details-a-summary',
+            'details-b-summary',
+            'visible-input',
+          ];
           assert.deepEqual(actual, expected);
         });
 
@@ -408,7 +412,11 @@ describe('tabbable', () => {
 
         it('details', () => {
           let actual = assertionSet.getFixture('details').getFocusableIds();
-          let expected = ['details-a-summary', 'details-b-summary', 'visible-input'];
+          let expected = [
+            'details-a-summary',
+            'details-b-summary',
+            'visible-input',
+          ];
           assert.deepEqual(actual.sort(), expected.sort());
         });
 

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -247,6 +247,7 @@ describe('tabbable', () => {
             'details-a-summary',
             'details-b-summary',
             'visible-input',
+            'details-c',
           ];
           assert.deepEqual(actual, expected);
         });
@@ -416,6 +417,7 @@ describe('tabbable', () => {
             'details-a-summary',
             'details-b-summary',
             'visible-input',
+            'details-c',
           ];
           assert.deepEqual(actual.sort(), expected.sort());
         });
@@ -478,6 +480,11 @@ describe('tabbable', () => {
             .getDocument()
             .getElementById('details-a-summary');
           assert.ok(isTabbable(n8));
+          let n9 = assertionSet
+            .getFixture('details')
+            .getDocument()
+            .getElementById('details-c');
+          assert.ok(isTabbable(n9));
         });
       });
 
@@ -523,6 +530,11 @@ describe('tabbable', () => {
             .getDocument()
             .getElementById('details-a-summary');
           assert.ok(isFocusable(n8));
+          let n9 = assertionSet
+            .getFixture('details')
+            .getDocument()
+            .getElementById('details-c');
+          assert.ok(isFocusable(n9));
         });
       });
     });

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -243,7 +243,7 @@ describe('tabbable', () => {
 
         it('details', () => {
           let actual = assertionSet.getFixture('details').getTabbableIds();
-          let expected = ['details-a-summery', 'details-b-summery'];
+          let expected = ['details-a-summery', 'details-b-summery', 'visible-input'];
           assert.deepEqual(actual, expected);
         });
 
@@ -408,7 +408,7 @@ describe('tabbable', () => {
 
         it('details', () => {
           let actual = assertionSet.getFixture('details').getFocusableIds();
-          let expected = ['details-a-summery', 'details-b-summery'];
+          let expected = ['details-a-summery', 'details-b-summery', 'visible-input'];
           assert.deepEqual(actual.sort(), expected.sort());
         });
 


### PR DESCRIPTION
This PR fixes some issues with the details/summary elements:

1. ignore elements nested under a closed details element with the exception of the first summary element.
2. ignore any summary elements except the first.
3. pickup details elements as tabbable in case they don't have any summary.

###  Features and Bug Fixes

- ~Issue being fixed is referenced.~
- [x] Test coverage added/updated.
- ~Typings added/updated.~
- [x] README updated (API changes, instructions, etc.).
- ~Changes to dependencies explained.~
- [x] Changeset added (run `yarn changeset` locally to add one, follow prompts).

