### PR TITLE
use matches fallback everywhere

### DIFF
--- a/.changeset/lucky-pots-add.md
+++ b/.changeset/lucky-pots-add.md
@@ -1,0 +1,5 @@
+---
+'tabbable': patch
+---
+
+use element.matches fallback for IE11 and Webkit5

--- a/src/index.js
+++ b/src/index.js
@@ -121,9 +121,9 @@ const isHidden = function (node) {
     return true;
   }
 
-  const isDirectSummary = node.matches('details>summary:first-of-type');
+  const isDirectSummary = matches.call(node, 'details>summary:first-of-type');
   const nodeUnderDetails = isDirectSummary ? node.parentElement : node;
-  if (nodeUnderDetails.matches('details:not([open]) *')) {
+  if (matches.call(nodeUnderDetails, 'details:not([open]) *')) {
     return true;
   }
 


### PR DESCRIPTION
This PR replaces the direct call to `element.matches` with the fallback for IE11 & Webkit5 where missing.
Fixes #156 

###  Features and Bug Fixes

- [x] Issue being fixed is referenced.
- [ ] ~Test coverage added/updated.~
- [ ] ~Typings added/updated.~
- [ ] ~README updated (API changes, instructions, etc.).~
- [ ] ~Changes to dependencies explained.~
- [x] Changeset added (run `yarn changeset` locally to add one, follow prompts).
