### PR TITLE
avoid calling `getComputedStyle` on all ancestors of a candidate

### DIFF
--- a/.changeset/shiny-experts-exercise.md
+++ b/.changeset/shiny-experts-exercise.md
@@ -1,0 +1,5 @@
+---
+'tabbable': patch
+---
+
+avoid calling `getComputedStyle` on all ancestors of a focusable candidate

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,12 @@ const isDetailsWithSummary = function (node) {
   return r;
 };
 
+const isFirstDirectSummaryInsideClosedDetails = function (node) {
+  const isDirectSummary = matches.call(node, 'details>summary:first-of-type');
+  const nodeUnderDetails = isDirectSummary ? node.parentElement : node;
+  return matches.call(nodeUnderDetails, 'details:not([open]) *');
+};
+
 const getCheckedRadio = function (nodes, form) {
   for (let i = 0; i < nodes.length; i++) {
     if (nodes[i].checked && nodes[i].form === form) {
@@ -140,25 +146,21 @@ const isNonTabbableRadio = function (node) {
   return isRadio(node) && !isTabbableRadio(node);
 };
 
+const hasZeroSize = function (node) {
+  const { width, height } = node.getBoundingClientRect();
+  return width === 0 && height === 0;
+};
+
+const isVisuallyHidden = function (node) {
+  return getComputedStyle(node).visibility === 'hidden';
+};
+
 const isHidden = function (node) {
-  if (getComputedStyle(node).visibility === 'hidden') {
-    return true;
-  }
-
-  const isDirectSummary = matches.call(node, 'details>summary:first-of-type');
-  const nodeUnderDetails = isDirectSummary ? node.parentElement : node;
-  if (matches.call(nodeUnderDetails, 'details:not([open]) *')) {
-    return true;
-  }
-
-  while (node) {
-    if (getComputedStyle(node).display === 'none') {
-      return true;
-    }
-    node = node.parentElement;
-  }
-
-  return false;
+  return (
+    isFirstDirectSummaryInsideClosedDetails(node) ||
+    hasZeroSize(node) ||
+    isVisuallyHidden(node)
+  );
 };
 
 const isNodeMatchingSelectorFocusable = function (node) {


### PR DESCRIPTION
`getBoundingClientRect()` returns a zero size when a node or any of it's ancestor has it's `display` style property set to `none`.
We leverage that fact to avoid checking computed styles for all ancestors of a focusable candidate.

While this doesn't prevent all unwanted style / layout recalculations, this should help mitigate the issue in #115 and [focus-trap#121](https://github.com/focus-trap/focus-trap/issues/121)

<details>
<summary>PR Checklist</summary>
<br/>

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
