### PR TITLE
display check configuration

### DIFF
--- a/.changeset/shy-ladybugs-kneel.md
+++ b/.changeset/shy-ladybugs-kneel.md
@@ -1,0 +1,5 @@
+---
+'tabbable': minor
+---
+
+Exposed an option to select the way that an element is checked as displayed

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Any of the above will _not_ be considered tabbable, though, if any of the follow
 
 - has a negative `tabindex` attribute
 - has a `disabled` attribute
-- either the node itself _or an ancestor of it_ is hidden via `display: none` or `visibility: hidden`
+- either the node itself _or an ancestor of it_ is hidden via `display: none` (*see ["Display check"](#display-check) below to modify this behavior)
+- has `visibility: hidden` style
 - is nested under a closed `<details>` element (with the exception of the first `<summary>` element)
 - is an `<input type="radio">` element and a different radio in its group is `checked`
 
@@ -83,27 +84,49 @@ Type: `boolean`. Default: `false`.
 
 If set to `true`, `rootNode` will be included in the returned tabbable node array, if `rootNode` is tabbable.
 
+##### displayCheck
+
+Type: `full` | `non-zero-area` | `none` . Default: `full`.
+
+configures how to check if an element is displayed, see ["Display check"](#display-check) below.
+
 ### isTabbable
 
 ```js
 import { isTabbable } from 'tabbable';
 
-isTabbable(node);
+isTabbable(node, [options]);
 ```
 
 Returns a boolean indicating whether the provided node is considered tabbable.
+
+#### options
+
+##### displayCheck
+
+Type: `full` | `non-zero-area` | `none` . Default: `full`.
+
+configures how to check if an element is displayed, see ["Display check"](#display-check) below.
 
 ### isFocusable
 
 ```js
 import { isFocusable } from 'tabbable';
 
-isFocusable(node);
+isFocusable(node, [options]);
 ```
 
 Returns a boolean indicating whether the provided node is considered _focusable_.
 
 All tabbable elements are focusable, but not all focusable elements are tabbable. For example, elements with `tabindex="-1"` are focusable but not tabbable.
+
+#### options
+
+##### displayCheck
+
+Type: `full` | `non-zero-area` | `none` . Default: `full`.
+
+configures how to check if an element is displayed, see ["Display check"](#display-check) below.
 
 ### focusable
 
@@ -127,15 +150,31 @@ Type: `boolean`. Default: `false`.
 
 If set to `true`, `rootNode` will be included in the returned focusable node array, if `rootNode` is focusable.
 
+##### displayCheck
+
+Type: `full` | `non-zero-area` | `none` . Default: `full`.
+
+configures how to check if an element is displayed, see ["Display check"](#display-check) below.
+
 ## More details
 
 - **Tabbable tries to identify elements that are reliably tabbable across (not dead) browsers.** Browsers are inconsistent in their behavior, though — especially for edge-case elements like `<object>` and `<iframe>` — so this means _some_ elements that you _can_ tab to in _some_ browsers will be left out of the results. (To learn more about this inconsistency, see this [amazing table](https://allyjs.io/data-tables/focusable.html)). To provide better consistency across browsers and ensure the elements you _want_ in your tabbables list show up there, **try adding `tabindex="0"` to edge-case elements that Tabbable ignores**.
 - (Exemplifying the above ^^:) **The tabbability of `<iframe>`s, `<embed>`s, `<object>`s, `<summary>`s, and `<svg>`s is [inconsistent across browsers](https://allyjs.io/data-tables/focusable.html)**, so if you need an accurate read on one of these elements you should try giving it a `tabindex`. (You'll also need to pay attention to the `focusable` attribute on SVGs in IE & Edge.) But you also might _not_ be able to get an accurate read — so you should avoid relying on it.
 - **Radio groups have some edge cases, which you can avoid by always having a `checked` one in each group** (and that is what you should usually do anyway). If there is no `checked` radio in the radio group, _all_ of the radios will be considered tabbable. (Some browsers do this, otherwise don't — there's not consistency.)
 - If you're thinking, "Why not just use the right `querySelectorAll`?", you _may_ be on to something ... but, as with most "just" statements, you're probably not. For example, a simple `querySelectorAll` approach will not figure out whether an element is _hidden_, and therefore not actually tabbable. (That said, if you do think Tabbable can be simplified or otherwise improved, I'd love to hear your idea.)
-- jQuery UI's `:tabbable` selector ignores elements with height and width of `0`. I'm not sure why — because I've found that I can still tab to those elements. So I kept them in. Only elements hidden with `display: none` or `visibility: hidden` are left out.
+- jQuery UI's `:tabbable` selector ignores elements with height and width of `0`. I'm not sure why — because I've found that I can still tab to those elements. So I kept them in. Only elements hidden with `display: none` or `visibility: hidden` are left out. See ["Display check"](#display-check) below for other options.
 - Although Tabbable tries to deal with positive tabindexes, **you should not use positive tabindexes**. Accessibility experts seem to be in (rare) unanimous and clear consent about this: rely on the order of elements in the document.
 - Safari on Mac OS X does not Tab to `<a>` elements by default: you have to change a setting to get the standard behavior. Tabbable does not know whether you've changed that setting or not, so it will include `<a>` elements in its list.
+
+### Display check
+
+To reliably check if an element is tabbable/focusable, Tabbable defaults to the most reliable option to keep consistent with browser behavior, however this comes at a cost since every node needs to be validated as displayed. The `full` process checks for computed display property of an element and each of the element ancestors. For this reason Tabbable offers the ability of an alternative way to check if an element is displayed (or completely opt out of the check).
+
+The `displayCheck` configuration accepts the following options:
+
+- `full`: (default) Most reliably resemble browser behavior, this option checks that an element is displayed and all of his ancestors are displayed as well (Notice that this doesn't exclude `visibility: hidden` or elements with zero size). This check is by far the slowest option as it might cause layout reflow.
+- `non-zero-area`: This option checks display under the assumption that elements that are not displayed have zero area (width AND height equals zero). While not keeping true to browser behavior, this option is much less intensive then the `full` option and better for accessibility as zero-size elements with focusable content are considered a strong accessibility anti-pattern.
+- `none`: This checks completely opt out of the display check. **This option is not recommended**, as it might return elements that are not displayed, and as such not tabbable/focusable and can break accessibility. Make sure you know which elements in your DOM are displayed and can filter them out yourself before using this option.
 
 **_Feedback and contributions more than welcome!_**
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The `displayCheck` configuration accepts the following options:
 
 - `full`: (default) Most reliably resemble browser behavior, this option checks that an element is displayed and all of his ancestors are displayed as well (Notice that this doesn't exclude `visibility: hidden` or elements with zero size). This check is by far the slowest option as it might cause layout reflow.
 - `non-zero-area`: This option checks display under the assumption that elements that are not displayed have zero area (width AND height equals zero). While not keeping true to browser behavior, this option is much less intensive then the `full` option and better for accessibility as zero-size elements with focusable content are considered a strong accessibility anti-pattern.
-- `none`: This checks completely opt out of the display check. **This option is not recommended**, as it might return elements that are not displayed, and as such not tabbable/focusable and can break accessibility. Make sure you know which elements in your DOM are displayed and can filter them out yourself before using this option.
+- `none`: This checks completely opt out of the display check. **This option is not recommended**, as it might return elements that are not displayed, and as such not tabbable/focusable and can break accessibility. Make sure you know which elements in your DOM are not displayed and can filter them out yourself before using this option.
 
 **_Feedback and contributions more than welcome!_**
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If set to `true`, `rootNode` will be included in the returned tabbable node arra
 
 Type: `full` | `non-zero-area` | `none` . Default: `full`.
 
-configures how to check if an element is displayed, see ["Display check"](#display-check) below.
+Configures how to check if an element is displayed, see ["Display check"](#display-check) below.
 
 ### isTabbable
 
@@ -106,7 +106,7 @@ Returns a boolean indicating whether the provided node is considered tabbable.
 
 Type: `full` | `non-zero-area` | `none` . Default: `full`.
 
-configures how to check if an element is displayed, see ["Display check"](#display-check) below.
+Configures how to check if an element is displayed, see ["Display check"](#display-check) below.
 
 ### isFocusable
 
@@ -126,7 +126,7 @@ All tabbable elements are focusable, but not all focusable elements are tabbable
 
 Type: `full` | `non-zero-area` | `none` . Default: `full`.
 
-configures how to check if an element is displayed, see ["Display check"](#display-check) below.
+Configures how to check if an element is displayed, see ["Display check"](#display-check) below.
 
 ### focusable
 
@@ -154,7 +154,7 @@ If set to `true`, `rootNode` will be included in the returned focusable node arr
 
 Type: `full` | `non-zero-area` | `none` . Default: `full`.
 
-configures how to check if an element is displayed, see ["Display check"](#display-check) below.
+Configures how to check if an element is displayed, see ["Display check"](#display-check) below.
 
 ## More details
 
@@ -174,7 +174,7 @@ The `displayCheck` configuration accepts the following options:
 
 - `full`: (default) Most reliably resemble browser behavior, this option checks that an element is displayed and all of his ancestors are displayed as well (Notice that this doesn't exclude `visibility: hidden` or elements with zero size). This check is by far the slowest option as it might cause layout reflow.
 - `non-zero-area`: This option checks display under the assumption that elements that are not displayed have zero area (width AND height equals zero). While not keeping true to browser behavior, this option is much less intensive then the `full` option and better for accessibility as zero-size elements with focusable content are considered a strong accessibility anti-pattern.
-- `none`: This checks completely opt out of the display check. **This option is not recommended**, as it might return elements that are not displayed, and as such not tabbable/focusable and can break accessibility. Make sure you know which elements in your DOM are not displayed and can filter them out yourself before using this option.
+- `none`: This completely opts out of the display check. **This option is not recommended**, as it might return elements that are not displayed, and as such not tabbable/focusable and can break accessibility. Make sure you know which elements in your DOM are not displayed and can filter them out yourself before using this option.
 
 **_Feedback and contributions more than welcome!_**
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,19 +1,29 @@
 type FocusableElement = HTMLElement | SVGElement;
 
+export type CheckOptions = {
+  displayCheck?: 'full' | 'non-zero-area' | 'none';
+};
+
 export type TabbableOptions = {
   includeContainer?: boolean;
 };
 
 export declare function tabbable(
   container: Element,
-  options?: TabbableOptions
+  options?: TabbableOptions & CheckOptions
 ): FocusableElement[];
 
 export declare function focusable(
   container: Element,
-  options?: TabbableOptions
+  options?: TabbableOptions & CheckOptions
 ): FocusableElement[];
 
-export declare function isTabbable(element: Element): boolean;
+export declare function isTabbable(
+  element: Element,
+  options?: CheckOptions
+): boolean;
 
-export declare function isFocusable(element: Element): boolean;
+export declare function isFocusable(
+  element: Element,
+  options?: CheckOptions
+): boolean;

--- a/test/fixtures/displayed.html
+++ b/test/fixtures/displayed.html
@@ -1,0 +1,17 @@
+<div id="displayed-top" tabindex="0">
+  <div id="displayed-nested" tabindex="0"></div>
+</div>
+<div
+  id="displayed-none-top"
+  tabindex="0"
+  style="display: none"
+  data-jsdom-no-size
+>
+  <div id="nested-under-displayed-none" tabindex="0" data-jsdom-no-size></div>
+</div>
+<div
+  id="displayed-zero-size"
+  tabindex="0"
+  style="width: 0; height: 0"
+  data-jsdom-no-size
+></div>

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -22,4 +22,5 @@ module.exports = {
     path.join(__dirname, 'shadow-dom.html'),
     'utf8'
   ),
+  displayed: fs.readFileSync(path.join(__dirname, 'displayed.html'), 'utf8'),
 };

--- a/test/focusable.test.js
+++ b/test/focusable.test.js
@@ -3,6 +3,7 @@ const fixtures = require('./fixtures/index.js');
 const {
   getIdsFromElementsArray,
   removeAllChildNodes,
+  mockElementsSizes,
 } = require('./helpers.js');
 
 describe('focusable', () => {
@@ -292,6 +293,68 @@ describe('focusable', () => {
         expect(getIdsFromElementsArray(focusableElements)).toEqual(
           expectedFocusableIds
         );
+      });
+
+      describe('displayed check', () => {
+        it('return browser visible elements by default ("full" option)', () => {
+          const expectedTabbableIds = [
+            'displayed-top',
+            'displayed-nested',
+            'displayed-zero-size',
+          ];
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.displayed;
+          mockElementsSizes(container);
+          document.body.append(container);
+
+          const tabbableElementsDefault = focusable(container);
+          const tabbableElementsFull = focusable(container, {
+            displayCheck: 'full',
+          });
+
+          expect(getIdsFromElementsArray(tabbableElementsDefault)).toEqual(
+            expectedTabbableIds
+          );
+          expect(getIdsFromElementsArray(tabbableElementsFull)).toEqual(
+            getIdsFromElementsArray(tabbableElementsDefault)
+          );
+        });
+        it('return only elements with size ("non-zero-area" option)', () => {
+          const expectedTabbableIds = ['displayed-top', 'displayed-nested'];
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.displayed;
+          mockElementsSizes(container);
+          document.body.append(container);
+
+          const tabbableElementsWithSize = focusable(container, {
+            displayCheck: 'non-zero-area',
+          });
+
+          expect(getIdsFromElementsArray(tabbableElementsWithSize)).toEqual(
+            expectedTabbableIds
+          );
+        });
+        it('return elements without checking display ("none" option)', () => {
+          const expectedTabbableIds = [
+            'displayed-top',
+            'displayed-nested',
+            'displayed-none-top',
+            'nested-under-displayed-none',
+            'displayed-zero-size',
+          ];
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.displayed;
+          mockElementsSizes(container);
+          document.body.append(container);
+
+          const tabbableElementsWithSize = focusable(container, {
+            displayCheck: 'none',
+          });
+
+          expect(getIdsFromElementsArray(tabbableElementsWithSize)).toEqual(
+            expectedTabbableIds
+          );
+        });
       });
     });
   });

--- a/test/focusable.test.js
+++ b/test/focusable.test.js
@@ -297,7 +297,7 @@ describe('focusable', () => {
 
       describe('displayed check', () => {
         it('return browser visible elements by default ("full" option)', () => {
-          const expectedTabbableIds = [
+          const expectedFocusableIds = [
             'displayed-top',
             'displayed-nested',
             'displayed-zero-size',
@@ -307,35 +307,35 @@ describe('focusable', () => {
           mockElementsSizes(container);
           document.body.append(container);
 
-          const tabbableElementsDefault = focusable(container);
-          const tabbableElementsFull = focusable(container, {
+          const focusableElementsDefault = focusable(container);
+          const focusableElementsFull = focusable(container, {
             displayCheck: 'full',
           });
 
-          expect(getIdsFromElementsArray(tabbableElementsDefault)).toEqual(
-            expectedTabbableIds
+          expect(getIdsFromElementsArray(focusableElementsDefault)).toEqual(
+            expectedFocusableIds
           );
-          expect(getIdsFromElementsArray(tabbableElementsFull)).toEqual(
-            getIdsFromElementsArray(tabbableElementsDefault)
+          expect(getIdsFromElementsArray(focusableElementsFull)).toEqual(
+            getIdsFromElementsArray(focusableElementsDefault)
           );
         });
         it('return only elements with size ("non-zero-area" option)', () => {
-          const expectedTabbableIds = ['displayed-top', 'displayed-nested'];
+          const expectedFocusableIds = ['displayed-top', 'displayed-nested'];
           const container = document.createElement('div');
           container.innerHTML = fixtures.displayed;
           mockElementsSizes(container);
           document.body.append(container);
 
-          const tabbableElementsWithSize = focusable(container, {
+          const focusableElementsWithSize = focusable(container, {
             displayCheck: 'non-zero-area',
           });
 
-          expect(getIdsFromElementsArray(tabbableElementsWithSize)).toEqual(
-            expectedTabbableIds
+          expect(getIdsFromElementsArray(focusableElementsWithSize)).toEqual(
+            expectedFocusableIds
           );
         });
         it('return elements without checking display ("none" option)', () => {
-          const expectedTabbableIds = [
+          const expectedFocusableIds = [
             'displayed-top',
             'displayed-nested',
             'displayed-none-top',
@@ -347,12 +347,12 @@ describe('focusable', () => {
           mockElementsSizes(container);
           document.body.append(container);
 
-          const tabbableElementsWithSize = focusable(container, {
+          const focusableElementsWithSize = focusable(container, {
             displayCheck: 'none',
           });
 
-          expect(getIdsFromElementsArray(tabbableElementsWithSize)).toEqual(
-            expectedTabbableIds
+          expect(getIdsFromElementsArray(focusableElementsWithSize)).toEqual(
+            expectedFocusableIds
           );
         });
       });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -7,3 +7,28 @@ export function removeAllChildNodes(parent) {
     parent.removeChild(parent.firstChild);
   }
 }
+
+/**
+ * Mock getBoundingClientRect since tests are
+ * running with jsdom and not a real browser
+ *
+ * By default all elements return a fixed size.
+ * Use the attribute "data-jsdom-no-size" to mark an element with zero width/height.
+ *
+ * @param {HTMLElement} container mock subtree getBoundingClientRect function
+ */
+export function mockElementsSizes(container) {
+  const elements = container.querySelectorAll('*');
+  for (const element of elements) {
+    const noSize = element.dataset.jsdomNoSize !== undefined;
+    const size = noSize ? 0 : 100;
+    element.getBoundingClientRect = () => ({
+      width: size,
+      height: size,
+      top: 0,
+      left: 0,
+      right: size,
+      bottom: size,
+    });
+  }
+}

--- a/test/isFocusable.test.js
+++ b/test/isFocusable.test.js
@@ -319,19 +319,31 @@ describe('isFocusable', () => {
       <div data-testid="nested-under-displayed-none" tabindex="0" data-jsdom-no-size></div>
     </div>
     `;
-    it('return browser visible elements by default ("full" option)', () => {
+    function setupDisplayCheck() {
       const container = document.createElement('div');
       container.innerHTML = fixture;
       mockElementsSizes(container);
       document.body.append(container);
-      const displayedTop = getByTestId(container, 'displayed-top');
-      const displayedNested = getByTestId(container, 'displayed-nested');
-      const displayedZeroSize = getByTestId(container, 'displayed-zero-size');
-      const displayedNoneTop = getByTestId(container, 'displayed-none-top');
-      const nestedUnderDisplayedNone = getByTestId(
-        container,
-        'nested-under-displayed-none'
-      );
+      return {
+        displayedTop: getByTestId(container, 'displayed-top'),
+        displayedNested: getByTestId(container, 'displayed-nested'),
+        displayedZeroSize: getByTestId(container, 'displayed-zero-size'),
+        displayedNoneTop: getByTestId(container, 'displayed-none-top'),
+        nestedUnderDisplayedNone: getByTestId(
+          container,
+          'nested-under-displayed-none'
+        ),
+      };
+    }
+
+    it('return browser visible elements by default ("full" option)', () => {
+      const {
+        displayedTop,
+        displayedNested,
+        displayedZeroSize,
+        displayedNoneTop,
+        nestedUnderDisplayedNone,
+      } = setupDisplayCheck();
 
       // default
       expect(isFocusable(displayedTop)).toBe(true);
@@ -348,18 +360,13 @@ describe('isFocusable', () => {
       expect(isFocusable(nestedUnderDisplayedNone)).toBe(false);
     });
     it('return only elements with size ("non-zero-area" option)', () => {
-      const container = document.createElement('div');
-      container.innerHTML = fixture;
-      mockElementsSizes(container);
-      document.body.append(container);
-      const displayedTop = getByTestId(container, 'displayed-top');
-      const displayedNested = getByTestId(container, 'displayed-nested');
-      const displayedZeroSize = getByTestId(container, 'displayed-zero-size');
-      const displayedNoneTop = getByTestId(container, 'displayed-none-top');
-      const nestedUnderDisplayedNone = getByTestId(
-        container,
-        'nested-under-displayed-none'
-      );
+      const {
+        displayedTop,
+        displayedNested,
+        displayedZeroSize,
+        displayedNoneTop,
+        nestedUnderDisplayedNone,
+      } = setupDisplayCheck();
 
       const options = { displayCheck: 'non-zero-area' };
       expect(isFocusable(displayedTop, options)).toBe(true);
@@ -369,18 +376,13 @@ describe('isFocusable', () => {
       expect(isFocusable(nestedUnderDisplayedNone, options)).toBe(false);
     });
     it('return elements without checking display ("none" option)', () => {
-      const container = document.createElement('div');
-      container.innerHTML = fixture;
-      mockElementsSizes(container);
-      document.body.append(container);
-      const displayedTop = getByTestId(container, 'displayed-top');
-      const displayedNested = getByTestId(container, 'displayed-nested');
-      const displayedZeroSize = getByTestId(container, 'displayed-zero-size');
-      const displayedNoneTop = getByTestId(container, 'displayed-none-top');
-      const nestedUnderDisplayedNone = getByTestId(
-        container,
-        'nested-under-displayed-none'
-      );
+      const {
+        displayedTop,
+        displayedNested,
+        displayedZeroSize,
+        displayedNoneTop,
+        nestedUnderDisplayedNone,
+      } = setupDisplayCheck();
 
       const options = { displayCheck: 'none' };
       expect(isFocusable(displayedTop, options)).toBe(true);

--- a/test/isFocusable.test.js
+++ b/test/isFocusable.test.js
@@ -1,6 +1,6 @@
 const { getByTestId, getByText } = require('@testing-library/dom');
 const { isFocusable } = require('../src/index.js');
-const { removeAllChildNodes } = require('./helpers.js');
+const { removeAllChildNodes, mockElementsSizes } = require('./helpers.js');
 
 describe('isFocusable', () => {
   afterEach(() => {
@@ -296,6 +296,98 @@ describe('isFocusable', () => {
       expect(
         isFocusable(getByTestId(container, 'childInputInOpenDetails'))
       ).toBe(true);
+    });
+  });
+
+  describe('display check', () => {
+    const fixture = `
+      <div data-testid="displayed-top" tabindex="0">
+        <div data-testid="displayed-nested" tabindex="0"></div>
+        <div
+          data-testid="displayed-zero-size"
+          tabindex="0"
+          style="width: 0; height: 0"
+          data-jsdom-no-size
+        ></div>
+      </div>
+      <div
+        data-testid="displayed-none-top"
+        tabindex="0"
+        style="display: none"
+        data-jsdom-no-size
+      >
+      <div data-testid="nested-under-displayed-none" tabindex="0" data-jsdom-no-size></div>
+    </div>
+    `;
+    it('return browser visible elements by default ("full" option)', () => {
+      const container = document.createElement('div');
+      container.innerHTML = fixture;
+      mockElementsSizes(container);
+      document.body.append(container);
+      const displayedTop = getByTestId(container, 'displayed-top');
+      const displayedNested = getByTestId(container, 'displayed-nested');
+      const displayedZeroSize = getByTestId(container, 'displayed-zero-size');
+      const displayedNoneTop = getByTestId(container, 'displayed-none-top');
+      const nestedUnderDisplayedNone = getByTestId(
+        container,
+        'nested-under-displayed-none'
+      );
+
+      // default
+      expect(isFocusable(displayedTop)).toBe(true);
+      expect(isFocusable(displayedNested)).toBe(true);
+      expect(isFocusable(displayedZeroSize)).toBe(true);
+      expect(isFocusable(displayedNoneTop)).toBe(false);
+      expect(isFocusable(nestedUnderDisplayedNone)).toBe(false);
+      // full
+      const options = { displayCheck: 'full' };
+      expect(isFocusable(displayedTop, options)).toBe(true);
+      expect(isFocusable(displayedNested, options)).toBe(true);
+      expect(isFocusable(displayedZeroSize, options)).toBe(true);
+      expect(isFocusable(displayedNoneTop)).toBe(false);
+      expect(isFocusable(nestedUnderDisplayedNone)).toBe(false);
+    });
+    it('return only elements with size ("non-zero-area" option)', () => {
+      const container = document.createElement('div');
+      container.innerHTML = fixture;
+      mockElementsSizes(container);
+      document.body.append(container);
+      const displayedTop = getByTestId(container, 'displayed-top');
+      const displayedNested = getByTestId(container, 'displayed-nested');
+      const displayedZeroSize = getByTestId(container, 'displayed-zero-size');
+      const displayedNoneTop = getByTestId(container, 'displayed-none-top');
+      const nestedUnderDisplayedNone = getByTestId(
+        container,
+        'nested-under-displayed-none'
+      );
+
+      const options = { displayCheck: 'non-zero-area' };
+      expect(isFocusable(displayedTop, options)).toBe(true);
+      expect(isFocusable(displayedNested, options)).toBe(true);
+      expect(isFocusable(displayedZeroSize, options)).toBe(false);
+      expect(isFocusable(displayedNoneTop, options)).toBe(false);
+      expect(isFocusable(nestedUnderDisplayedNone, options)).toBe(false);
+    });
+    it('return elements without checking display ("none" option)', () => {
+      const container = document.createElement('div');
+      container.innerHTML = fixture;
+      mockElementsSizes(container);
+      document.body.append(container);
+      const displayedTop = getByTestId(container, 'displayed-top');
+      const displayedNested = getByTestId(container, 'displayed-nested');
+      const displayedZeroSize = getByTestId(container, 'displayed-zero-size');
+      const displayedNoneTop = getByTestId(container, 'displayed-none-top');
+      const nestedUnderDisplayedNone = getByTestId(
+        container,
+        'nested-under-displayed-none'
+      );
+
+      const options = { displayCheck: 'none' };
+      expect(isFocusable(displayedTop, options)).toBe(true);
+      expect(isFocusable(displayedNested, options)).toBe(true);
+      expect(isFocusable(displayedZeroSize, options)).toBe(true);
+      expect(isFocusable(displayedNoneTop, options)).toBe(true);
+      expect(isFocusable(nestedUnderDisplayedNone, options)).toBe(true);
     });
   });
 });

--- a/test/isTabbable.test.js
+++ b/test/isTabbable.test.js
@@ -1,6 +1,6 @@
 const { getByTestId, getByText } = require('@testing-library/dom');
 const { isTabbable } = require('../src/index.js');
-const { removeAllChildNodes } = require('./helpers.js');
+const { removeAllChildNodes, mockElementsSizes } = require('./helpers.js');
 
 describe('isTabbable', () => {
   afterEach(() => {
@@ -291,6 +291,98 @@ describe('isTabbable', () => {
 
       expect(isTabbable(getByTestId(container, 'radioA'))).toBe(true);
       expect(isTabbable(getByTestId(container, 'radioB'))).toBe(false);
+    });
+  });
+
+  describe('display check', () => {
+    const fixture = `
+      <div data-testid="displayed-top" tabindex="0">
+        <div data-testid="displayed-nested" tabindex="0"></div>
+        <div
+          data-testid="displayed-zero-size"
+          tabindex="0"
+          style="width: 0; height: 0"
+          data-jsdom-no-size
+        ></div>
+      </div>
+      <div
+        data-testid="displayed-none-top"
+        tabindex="0"
+        style="display: none"
+        data-jsdom-no-size
+      >
+      <div data-testid="nested-under-displayed-none" tabindex="0" data-jsdom-no-size></div>
+    </div>
+    `;
+    it('return browser visible elements by default ("full" option)', () => {
+      const container = document.createElement('div');
+      container.innerHTML = fixture;
+      mockElementsSizes(container);
+      document.body.append(container);
+      const displayedTop = getByTestId(container, 'displayed-top');
+      const displayedNested = getByTestId(container, 'displayed-nested');
+      const displayedZeroSize = getByTestId(container, 'displayed-zero-size');
+      const displayedNoneTop = getByTestId(container, 'displayed-none-top');
+      const nestedUnderDisplayedNone = getByTestId(
+        container,
+        'nested-under-displayed-none'
+      );
+
+      // default
+      expect(isTabbable(displayedTop)).toBe(true);
+      expect(isTabbable(displayedNested)).toBe(true);
+      expect(isTabbable(displayedZeroSize)).toBe(true);
+      expect(isTabbable(displayedNoneTop)).toBe(false);
+      expect(isTabbable(nestedUnderDisplayedNone)).toBe(false);
+      // full
+      const options = { displayCheck: 'full' };
+      expect(isTabbable(displayedTop, options)).toBe(true);
+      expect(isTabbable(displayedNested, options)).toBe(true);
+      expect(isTabbable(displayedZeroSize, options)).toBe(true);
+      expect(isTabbable(displayedNoneTop)).toBe(false);
+      expect(isTabbable(nestedUnderDisplayedNone)).toBe(false);
+    });
+    it('return only elements with size ("non-zero-area" option)', () => {
+      const container = document.createElement('div');
+      container.innerHTML = fixture;
+      mockElementsSizes(container);
+      document.body.append(container);
+      const displayedTop = getByTestId(container, 'displayed-top');
+      const displayedNested = getByTestId(container, 'displayed-nested');
+      const displayedZeroSize = getByTestId(container, 'displayed-zero-size');
+      const displayedNoneTop = getByTestId(container, 'displayed-none-top');
+      const nestedUnderDisplayedNone = getByTestId(
+        container,
+        'nested-under-displayed-none'
+      );
+
+      const options = { displayCheck: 'non-zero-area' };
+      expect(isTabbable(displayedTop, options)).toBe(true);
+      expect(isTabbable(displayedNested, options)).toBe(true);
+      expect(isTabbable(displayedZeroSize, options)).toBe(false);
+      expect(isTabbable(displayedNoneTop, options)).toBe(false);
+      expect(isTabbable(nestedUnderDisplayedNone, options)).toBe(false);
+    });
+    it('return elements without checking display ("none" option)', () => {
+      const container = document.createElement('div');
+      container.innerHTML = fixture;
+      mockElementsSizes(container);
+      document.body.append(container);
+      const displayedTop = getByTestId(container, 'displayed-top');
+      const displayedNested = getByTestId(container, 'displayed-nested');
+      const displayedZeroSize = getByTestId(container, 'displayed-zero-size');
+      const displayedNoneTop = getByTestId(container, 'displayed-none-top');
+      const nestedUnderDisplayedNone = getByTestId(
+        container,
+        'nested-under-displayed-none'
+      );
+
+      const options = { displayCheck: 'none' };
+      expect(isTabbable(displayedTop, options)).toBe(true);
+      expect(isTabbable(displayedNested, options)).toBe(true);
+      expect(isTabbable(displayedZeroSize, options)).toBe(true);
+      expect(isTabbable(displayedNoneTop, options)).toBe(true);
+      expect(isTabbable(nestedUnderDisplayedNone, options)).toBe(true);
     });
   });
 });

--- a/test/isTabbable.test.js
+++ b/test/isTabbable.test.js
@@ -314,19 +314,30 @@ describe('isTabbable', () => {
       <div data-testid="nested-under-displayed-none" tabindex="0" data-jsdom-no-size></div>
     </div>
     `;
-    it('return browser visible elements by default ("full" option)', () => {
+    function setupDisplayCheck() {
       const container = document.createElement('div');
       container.innerHTML = fixture;
       mockElementsSizes(container);
       document.body.append(container);
-      const displayedTop = getByTestId(container, 'displayed-top');
-      const displayedNested = getByTestId(container, 'displayed-nested');
-      const displayedZeroSize = getByTestId(container, 'displayed-zero-size');
-      const displayedNoneTop = getByTestId(container, 'displayed-none-top');
-      const nestedUnderDisplayedNone = getByTestId(
-        container,
-        'nested-under-displayed-none'
-      );
+      return {
+        displayedTop: getByTestId(container, 'displayed-top'),
+        displayedNested: getByTestId(container, 'displayed-nested'),
+        displayedZeroSize: getByTestId(container, 'displayed-zero-size'),
+        displayedNoneTop: getByTestId(container, 'displayed-none-top'),
+        nestedUnderDisplayedNone: getByTestId(
+          container,
+          'nested-under-displayed-none'
+        ),
+      };
+    }
+    it('return browser visible elements by default ("full" option)', () => {
+      const {
+        displayedTop,
+        displayedNested,
+        displayedZeroSize,
+        displayedNoneTop,
+        nestedUnderDisplayedNone,
+      } = setupDisplayCheck();
 
       // default
       expect(isTabbable(displayedTop)).toBe(true);
@@ -343,18 +354,13 @@ describe('isTabbable', () => {
       expect(isTabbable(nestedUnderDisplayedNone)).toBe(false);
     });
     it('return only elements with size ("non-zero-area" option)', () => {
-      const container = document.createElement('div');
-      container.innerHTML = fixture;
-      mockElementsSizes(container);
-      document.body.append(container);
-      const displayedTop = getByTestId(container, 'displayed-top');
-      const displayedNested = getByTestId(container, 'displayed-nested');
-      const displayedZeroSize = getByTestId(container, 'displayed-zero-size');
-      const displayedNoneTop = getByTestId(container, 'displayed-none-top');
-      const nestedUnderDisplayedNone = getByTestId(
-        container,
-        'nested-under-displayed-none'
-      );
+      const {
+        displayedTop,
+        displayedNested,
+        displayedZeroSize,
+        displayedNoneTop,
+        nestedUnderDisplayedNone,
+      } = setupDisplayCheck();
 
       const options = { displayCheck: 'non-zero-area' };
       expect(isTabbable(displayedTop, options)).toBe(true);
@@ -364,18 +370,13 @@ describe('isTabbable', () => {
       expect(isTabbable(nestedUnderDisplayedNone, options)).toBe(false);
     });
     it('return elements without checking display ("none" option)', () => {
-      const container = document.createElement('div');
-      container.innerHTML = fixture;
-      mockElementsSizes(container);
-      document.body.append(container);
-      const displayedTop = getByTestId(container, 'displayed-top');
-      const displayedNested = getByTestId(container, 'displayed-nested');
-      const displayedZeroSize = getByTestId(container, 'displayed-zero-size');
-      const displayedNoneTop = getByTestId(container, 'displayed-none-top');
-      const nestedUnderDisplayedNone = getByTestId(
-        container,
-        'nested-under-displayed-none'
-      );
+      const {
+        displayedTop,
+        displayedNested,
+        displayedZeroSize,
+        displayedNoneTop,
+        nestedUnderDisplayedNone,
+      } = setupDisplayCheck();
 
       const options = { displayCheck: 'none' };
       expect(isTabbable(displayedTop, options)).toBe(true);

--- a/test/tabbable.test.js
+++ b/test/tabbable.test.js
@@ -4,6 +4,7 @@ const fixtures = require('./fixtures/index.js');
 const {
   getIdsFromElementsArray,
   removeAllChildNodes,
+  mockElementsSizes,
 } = require('./helpers.js');
 
 describe('tabbable', () => {
@@ -322,6 +323,68 @@ describe('tabbable', () => {
         expect(getIdsFromElementsArray(tabbableElements)).toEqual(
           expectedTabbableIds
         );
+      });
+
+      describe('displayed check', () => {
+        it('return browser visible elements by default ("full" option)', () => {
+          const expectedTabbableIds = [
+            'displayed-top',
+            'displayed-nested',
+            'displayed-zero-size',
+          ];
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.displayed;
+          mockElementsSizes(container);
+          document.body.append(container);
+
+          const tabbableElementsDefault = tabbable(container);
+          const tabbableElementsFull = tabbable(container, {
+            displayCheck: 'full',
+          });
+
+          expect(getIdsFromElementsArray(tabbableElementsDefault)).toEqual(
+            expectedTabbableIds
+          );
+          expect(getIdsFromElementsArray(tabbableElementsFull)).toEqual(
+            getIdsFromElementsArray(tabbableElementsDefault)
+          );
+        });
+        it('return only elements with size ("non-zero-area" option)', () => {
+          const expectedTabbableIds = ['displayed-top', 'displayed-nested'];
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.displayed;
+          mockElementsSizes(container);
+          document.body.append(container);
+
+          const tabbableElementsWithSize = tabbable(container, {
+            displayCheck: 'non-zero-area',
+          });
+
+          expect(getIdsFromElementsArray(tabbableElementsWithSize)).toEqual(
+            expectedTabbableIds
+          );
+        });
+        it('return elements without checking display ("none" option)', () => {
+          const expectedTabbableIds = [
+            'displayed-top',
+            'displayed-nested',
+            'displayed-none-top',
+            'nested-under-displayed-none',
+            'displayed-zero-size',
+          ];
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.displayed;
+          mockElementsSizes(container);
+          document.body.append(container);
+
+          const tabbableElementsWithSize = tabbable(container, {
+            displayCheck: 'none',
+          });
+
+          expect(getIdsFromElementsArray(tabbableElementsWithSize)).toEqual(
+            expectedTabbableIds
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
This PR adds the ability to configure how an element is checked for display. The default behavior is kept as it was, with 2 additional options for an alternative size based check and an opt out option added.

The option `displayCheck` is added to all 4 checking methods of Tabbable.

In order to check the size based option, `getBoundingClientRect` had to be mocked, since Tabbable is checked using jsdom and no longer checked against a real browser. I think this is a miss (I certainly missed this move in the refactor) and we should consider moving back to actual browser testing (against multiple browsers) as this library is trying to integrate with low level browser APIs and mimic browser behavior. 

<details>
<summary>PR Checklist</summary>
<br/>

- Source changes maintain stated browser compatibility.
- Issue that started this PR: #115 .
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- README updated (API changes, instructions, etc.).
- Changeset added

</details>
