### PR TITLE
browser testing cleanups

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -17,13 +17,15 @@
  */
 // eslint-disable-next-line no-unused-vars
 module.exports = (on, config) => {
-  // enable coverage
-  require('@cypress/code-coverage/task')(on, config);
-  // instrument code
-  on(
-    'file:preprocessor',
-    require('@cypress/code-coverage/use-browserify-istanbul')
-  );
+  if (config.env.coverage === true) {
+    // enable coverage
+    require('@cypress/code-coverage/task')(on, config);
+    // instrument code
+    on(
+      'file:preprocessor',
+      require('@cypress/code-coverage/use-browserify-istanbul')
+    );
+  }
   // fetch fixtures
   on('task', {
     getFixtures() {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:unit": "jest",
     "test:e2e": "cypress run",
     "test:e2e:dev": "cypress open",
+    "test:coverage": "cypress run --env coverage=true",
     "prepare": "yarn build",
     "release": "yarn build && changeset publish"
   },

--- a/test/e2e/focusable.e2e.js
+++ b/test/e2e/focusable.e2e.js
@@ -46,16 +46,6 @@ describe('isFocusable', () => {
       container.innerHTML = fixtures.basic;
       document.body.append(container);
 
-      // JSDOM does not support the `contenteditable` attribute, so we need to fake it
-      // https://github.com/jsdom/jsdom/issues/1670
-      const editableDiv = container.querySelector('#contenteditable-true');
-      const editableNestedDiv = container.querySelector(
-        '#contenteditable-nesting'
-      );
-
-      editableDiv.contentEditable = 'true';
-      editableNestedDiv.contentEditable = 'true';
-
       const focusableElements = focusable(container);
 
       expect(getIdsFromElementsArray(focusableElements)).to.eql(

--- a/test/e2e/isFocusable.e2e.js
+++ b/test/e2e/isFocusable.e2e.js
@@ -101,8 +101,6 @@ describe('isFocusable', () => {
       expect(isFocusable(getByText(container, 'Details content'))).to.eql(true);
     });
 
-    // JSDOM does not support the `contenteditable` attribute, so we need to fake it
-    // https://github.com/jsdom/jsdom/issues/1670
     it('returns true for any element with a `contenteditable` attribute with a truthy value', () => {
       const container = document.createElement('div');
       container.innerHTML = `<div contenteditable="true">contenteditable div</div>
@@ -114,9 +112,6 @@ describe('isFocusable', () => {
         container,
         'contenteditable paragraph'
       );
-
-      editableDiv.contentEditable = 'true';
-      editableParagraph.contentEditable = 'true';
 
       expect(isFocusable(editableDiv)).to.eql(true);
       expect(isFocusable(editableParagraph)).to.eql(true);
@@ -215,8 +210,6 @@ describe('isFocusable', () => {
       expect(isFocusable(getByText(container, 'Summary'))).to.eql(false);
     });
 
-    // JSDOM does not support the `contenteditable` attribute, so we need to fake it
-    // https://github.com/jsdom/jsdom/issues/1670
     it('returns false for any element with a `contenteditable` attribute with a falsy value', () => {
       const container = document.createElement('div');
       container.innerHTML = `<div contenteditable="false">contenteditable div</div>
@@ -228,9 +221,6 @@ describe('isFocusable', () => {
         container,
         'contenteditable paragraph'
       );
-
-      editableDiv.contentEditable = 'false';
-      editableParagraph.contentEditable = 'false';
 
       expect(isFocusable(editableDiv)).to.eql(false);
       expect(isFocusable(editableParagraph)).to.eql(false);
@@ -320,16 +310,14 @@ describe('isFocusable', () => {
           data-testid="displayed-zero-size"
           tabindex="0"
           style="width: 0; height: 0"
-          data-jsdom-no-size
         ></div>
       </div>
       <div
         data-testid="displayed-none-top"
         tabindex="0"
         style="display: none"
-        data-jsdom-no-size
       >
-      <div data-testid="nested-under-displayed-none" tabindex="0" data-jsdom-no-size></div>
+      <div data-testid="nested-under-displayed-none" tabindex="0"></div>
     </div>
     `;
     function setupDisplayCheck() {

--- a/test/e2e/isTabbable.e2e.js
+++ b/test/e2e/isTabbable.e2e.js
@@ -101,8 +101,6 @@ describe('isTabbable', () => {
       expect(isTabbable(getByText(container, 'Details content'))).to.eql(true);
     });
 
-    // JSDOM does not support the `contenteditable` attribute, so we need to fake it
-    // https://github.com/jsdom/jsdom/issues/1670
     it('returns true for any element with a `contenteditable` attribute with a truthy value', () => {
       const container = document.createElement('div');
       container.innerHTML = `<div contenteditable="true">contenteditable div</div>
@@ -114,9 +112,6 @@ describe('isTabbable', () => {
         container,
         'contenteditable paragraph'
       );
-
-      editableDiv.contentEditable = 'true';
-      editableParagraph.contentEditable = 'true';
 
       expect(isTabbable(editableDiv)).to.eql(true);
       expect(isTabbable(editableParagraph)).to.eql(true);
@@ -182,8 +177,6 @@ describe('isTabbable', () => {
       expect(isTabbable(getByText(container, 'Summary'))).to.eql(false);
     });
 
-    // JSDOM does not support the `contenteditable` attribute, so we need to fake it
-    // https://github.com/jsdom/jsdom/issues/1670
     it('returns false for any element with a `contenteditable` attribute with a falsy value', () => {
       const container = document.createElement('div');
       container.innerHTML = `<div contenteditable="false">contenteditable div</div>
@@ -195,9 +188,6 @@ describe('isTabbable', () => {
         container,
         'contenteditable paragraph'
       );
-
-      editableDiv.contentEditable = 'false';
-      editableParagraph.contentEditable = 'false';
 
       expect(isTabbable(editableDiv)).to.eql(false);
       expect(isTabbable(editableParagraph)).to.eql(false);
@@ -311,16 +301,14 @@ describe('isTabbable', () => {
           data-testid="displayed-zero-size"
           tabindex="0"
           style="width: 0; height: 0"
-          data-jsdom-no-size
         ></div>
       </div>
       <div
         data-testid="displayed-none-top"
         tabindex="0"
         style="display: none"
-        data-jsdom-no-size
       >
-      <div data-testid="nested-under-displayed-none" tabindex="0" data-jsdom-no-size></div>
+      <div data-testid="nested-under-displayed-none" tabindex="0"></div>
     </div>
     `;
     function setupDisplayCheck() {

--- a/test/e2e/tabbable.e2e.js
+++ b/test/e2e/tabbable.e2e.js
@@ -21,7 +21,7 @@ describe('tabbable', () => {
     removeAllChildNodes(document.body);
   });
 
-  describe('example fixtures', () => {
+  describe.skip('example fixtures', () => {
     it('correctly identifies tabbable elements in the "basic" example', () => {
       const expectedTabbableIds = [
         'tabindex-hrefless-anchor',

--- a/test/e2e/tabbable.e2e.js
+++ b/test/e2e/tabbable.e2e.js
@@ -45,16 +45,6 @@ describe('tabbable', () => {
       container.innerHTML = fixtures.basic;
       document.body.append(container);
 
-      // JSDOM does not support the `contenteditable` attribute, so we need to fake it
-      // https://github.com/jsdom/jsdom/issues/1670
-      const editableDiv = container.querySelector('#contenteditable-true');
-      const editableNestedDiv = container.querySelector(
-        '#contenteditable-nesting'
-      );
-
-      editableDiv.contentEditable = 'true';
-      editableNestedDiv.contentEditable = 'true';
-
       const tabbableElements = tabbable(container);
 
       expect(getIdsFromElementsArray(tabbableElements)).to.eql(

--- a/test/e2e/tabbable.e2e.js
+++ b/test/e2e/tabbable.e2e.js
@@ -21,7 +21,7 @@ describe('tabbable', () => {
     removeAllChildNodes(document.body);
   });
 
-  describe.skip('example fixtures', () => {
+  describe('example fixtures', () => {
     it('correctly identifies tabbable elements in the "basic" example', () => {
       const expectedTabbableIds = [
         'tabindex-hrefless-anchor',

--- a/test/fixtures/displayed.html
+++ b/test/fixtures/displayed.html
@@ -1,17 +1,7 @@
 <div id="displayed-top" tabindex="0">
   <div id="displayed-nested" tabindex="0"></div>
 </div>
-<div
-  id="displayed-none-top"
-  tabindex="0"
-  style="display: none"
-  data-jsdom-no-size
->
-  <div id="nested-under-displayed-none" tabindex="0" data-jsdom-no-size></div>
+<div id="displayed-none-top" tabindex="0" style="display: none">
+  <div id="nested-under-displayed-none" tabindex="0"></div>
 </div>
-<div
-  id="displayed-zero-size"
-  tabindex="0"
-  style="width: 0; height: 0"
-  data-jsdom-no-size
-></div>
+<div id="displayed-zero-size" tabindex="0" style="width: 0; height: 0"></div>


### PR DESCRIPTION
Testing how to move forward with web components I found some leftovers:

- removes leftovers mocks and markers for JSDOM
- generates coverage and insert code instrumentation just when coverage needs to be collected - I missed the fact that  in addition to creating coverage every time a test run, it caused debugging to be annoying with extra step throughs over each line.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- ~~Issue being fixed is referenced.~~
- ~~Unit test coverage added/updated.~~
- E2E test coverage updated.
- ~~Typings added/updated.~~
- ~~README updated (API changes, instructions, etc.).~~
- ~~Changes to dependencies explained.~~
- ~~Changeset added~~

</details>
