### PR TITLE
shadow dom support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.3.0-beta.1
+
+- Includes new Shadow DOM support for open shadows by default
+- Includes a new `getShadowRoot()` configuration option, enabling support for closed shadows
+
 ## 5.2.1
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ Type: `full` | `non-zero-area` | `none` . Default: `full`.
 
 Configures how to check if an element is displayed, see ["Display check"](#display-check) below.
 
+##### getShadowRoot
+
+Type: `(node: FocusableElement) => ShadowRoot | boolean | undefined`
+
+Returns the node's `ShadowRoot` if available, or a `boolean` indicating if a `ShadowRoot` is attached but not available. `node` will be a descendent of the `rootNode` given to `tabbable()`.
+
+If `true` is returned, Tabbable assumes a closed `ShadowRoot` is attached and will iterate the `node`'s children for additional tabbable/focusable candidates.
+
+If a falsy value is returned, all children will be ignored as candidates.
+
 ### isTabbable
 
 ```js

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ type FocusableElement = HTMLElement | SVGElement;
 
 export type CheckOptions = {
   displayCheck?: 'full' | 'non-zero-area' | 'none';
-  getShadowDom?: (node: FocusableElement) => boolean | undefined;
+  getShadowRoot?: (node: FocusableElement) => ShadowRoot | boolean | undefined;
 };
 
 export type TabbableOptions = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ type FocusableElement = HTMLElement | SVGElement;
 
 export type CheckOptions = {
   displayCheck?: 'full' | 'non-zero-area' | 'none';
+  getShadowDom?: (node: FocusableElement) => boolean | undefined;
 };
 
 export type TabbableOptions = {

--- a/src/index.js
+++ b/src/index.js
@@ -244,7 +244,7 @@ const isZeroArea = function (node) {
   const { width, height } = node.getBoundingClientRect();
   return width === 0 && height === 0;
 };
-const isHidden = function (node, options) {
+const isHidden = function (node, { displayCheck, getShadowRoot = noop }) {
   if (getComputedStyle(node).visibility === 'hidden') {
     return true;
   }
@@ -254,8 +254,7 @@ const isHidden = function (node, options) {
   if (matches.call(nodeUnderDetails, 'details:not([open]) *')) {
     return true;
   }
-  const displayCheck = options.displayCheck;
-  const getShadowRoot = options.getShadowRoot || noop;
+
   if (!displayCheck || displayCheck === 'full') {
     while (node) {
       if (getComputedStyle(node).display === 'none') {

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,8 @@ const isTabbableRadio = function (node) {
   if (!node.name) {
     return true;
   }
-  const radioScope = node.form || node.ownerDocument;
+  const radioScope =
+    node.form || node.getRootNode ? node.getRootNode() : node.ownerDocument;
 
   const queryRadios = function (name) {
     return radioScope.querySelectorAll(

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const candidateSelectors = [
   'textarea',
   'a[href]',
   'button',
-  '[tabindex]',
+  '[tabindex]:not(slot)',
   'audio[controls]',
   'video[controls]',
   '[contenteditable]:not([contenteditable="false"])',

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,12 @@ const getRootNode =
     ? (element) => element.getRootNode()
     : (element) => element.ownerDocument;
 
+/**
+ * @param {Element} el container to check in
+ * @param {boolean} includeContainer add container to check
+ * @param {(node: Element) => boolean} filter filter candidates
+ * @returns {Element[]}
+ */
 const getCandidates = function (el, includeContainer, filter) {
   let candidates = Array.prototype.slice.apply(
     el.querySelectorAll(candidateSelector)
@@ -37,6 +43,31 @@ const getCandidates = function (el, includeContainer, filter) {
   return candidates;
 };
 
+/**
+ * @callback GetShadowRoot
+ * @param {Element} element to check for shadow root
+ * @returns {ShadowRoot|boolean} ShadowRoot if available or boolean indicating if a shadowRoot is attached but not available.
+ */
+
+/**
+ * @typedef {Object} CandidatesScope
+ * @property {Element} scope contains inner candidates
+ * @property {Element[]} candidates
+ */
+
+/**
+ * @typedef {Object} IterativeOptions
+ * @property {GetShadowRoot} getShadowRoot returns the shadow root of an element or a boolean stating if it has a shadow root
+ * @property {(node: Element) => boolean} filter filter candidates
+ * @property {boolean} flatten if true then result will flatten any CandidatesScope into the returned list
+ */
+
+/**
+ * @param {Element[]} elements list of element containers to match candidates from
+ * @param {boolean} includeContainer add container list to check
+ * @param {IterativeOptions} options
+ * @returns {Array.<Element|CandidatesScope>}
+ */
 const getCandidatesIteratively = function (
   elements,
   includeContainer,
@@ -326,6 +357,10 @@ const isNodeMatchingSelectorTabbable = function (options, node) {
   return true;
 };
 
+/**
+ * @param {Array.<Element|CandidatesScope>} candidates
+ * @returns Element[]
+ */
 const sortByOrder = function (candidates) {
   const regularTabbables = [];
   const orderedTabbables = [];

--- a/test/e2e/e2e.helpers.js
+++ b/test/e2e/e2e.helpers.js
@@ -1,3 +1,5 @@
+import { appendHTMLWithShadowRoots } from '../shadow-root-utils';
+
 export function setupTestWindow(done) {
   cy.visit('./cypress/test-sandbox.html');
   cy.window().then(done);
@@ -13,9 +15,23 @@ export function removeAllChildNodes(parent) {
     parent.removeChild(parent.firstChild);
   }
 }
-export function setupFixture(content) {
-  const container = document.createElement('div');
-  container.innerHTML = content;
-  document.body.append(container);
+
+/**
+ * Renders a fixture into the body with support for shadow dom hydration
+ *
+ * @param {string} content        html content to be used as fixture
+ * @param {window} options.window window to run the fixture in
+ * @param {window} options.caseId subtree element id to render from the fixture
+ * @returns {HTMLDivElement} return.container the element the fixture was rendered into
+ */
+export function setupFixture(content, options = {}) {
+  const win = options.window || window;
+  const doc = win.document;
+  const container = doc.createElement('div');
+  appendHTMLWithShadowRoots(container, content, {
+    win,
+    caseId: options.caseId,
+  });
+  doc.body.append(container);
   return { container };
 }

--- a/test/e2e/e2e.helpers.js
+++ b/test/e2e/e2e.helpers.js
@@ -17,11 +17,15 @@ export function removeAllChildNodes(parent) {
 }
 
 /**
+ * @typedef {Object} SetupFixtureOptions
+ * @property {Window=} window to setup in (defaults to test context window)
+ * @property {string=} caseId subtree element id to render from the fixture
+ */
+
+/**
  * Renders a fixture into the body with support for shadow dom hydration
- *
- * @param {string} content        html content to be used as fixture
- * @param {window} options.window window to run the fixture in
- * @param {window} options.caseId subtree element id to render from the fixture
+ * @param {string} content html content to be used as fixture
+ * @param {SetupFixtureOptions} options
  * @returns {HTMLDivElement} return.container the element the fixture was rendered into
  */
 export function setupFixture(content, options = {}) {

--- a/test/e2e/focusable.e2e.js
+++ b/test/e2e/focusable.e2e.js
@@ -2,6 +2,7 @@ import { focusable } from '../../src/index.js';
 import {
   setupTestWindow,
   getFixtures,
+  setupFixture,
   removeAllChildNodes,
   getIdsFromElementsArray,
 } from './e2e.helpers';
@@ -261,17 +262,12 @@ describe('focusable', () => {
     it('correctly identifies focusable elements in the "shadow-dom" example', () => {
       const expectedFocusableIds = ['input'];
 
-      const container = document.createElement('div');
-      container.innerHTML = fixtures['shadow-dom'];
-      document.body.append(container);
+      const { container } = setupFixture(fixtures['shadow-dom'], { window });
+      const host = container.querySelector('test-shadow');
 
-      const host = container.querySelector('#shadow-host');
-      const template = container.querySelector('#shadow-root-template');
-
-      const shadow = host.attachShadow({ mode: 'open' });
-      shadow.appendChild(template.content.cloneNode(true));
-
-      const focusableElements = focusable(shadow.querySelector('#container'));
+      const focusableElements = focusable(
+        host.shadowRoot.querySelector('#container')
+      );
 
       expect(getIdsFromElementsArray(focusableElements)).to.eql(
         expectedFocusableIds

--- a/test/e2e/shadow-dom.e2e.js
+++ b/test/e2e/shadow-dom.e2e.js
@@ -1,9 +1,15 @@
-import { isTabbable, isFocusable } from '../../src/index.js';
+import {
+  isTabbable,
+  isFocusable,
+  tabbable,
+  focusable,
+} from '../../src/index.js';
 import {
   setupTestWindow,
   removeAllChildNodes,
   setupFixture,
   getFixtures,
+  getIdsFromElementsArray,
 } from './e2e.helpers';
 
 describe('web-components', () => {
@@ -105,6 +111,263 @@ describe('web-components', () => {
         }),
         'fallback to zero size for unreached shadow root'
       ).to.eql(false);
+    });
+  });
+  describe('query', () => {
+    it('should find elements inside shadow dom', () => {
+      const expected = ['light-before', 'shadow-input', 'light-after'];
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'shadow-input',
+      });
+
+      const result = tabbable(container, { getShadowRoot() {} });
+
+      expect(getIdsFromElementsArray(result)).to.eql(expected);
+    });
+
+    it('should find elements inside shadow dom when directly querying the element with shadow root', () => {
+      const expected = ['shadow-input'];
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'shadow-input',
+      });
+      const shadowElement = container.querySelector('test-shadow');
+
+      const result = tabbable(shadowElement, { getShadowRoot() {} });
+
+      expect(getIdsFromElementsArray(result)).to.eql(expected);
+    });
+
+    it('should find elements inside shadow dom when directly querying the element with shadow root (include container)', () => {
+      const expected = ['shadow-host', 'shadow-input'];
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'shadow-input',
+      });
+      const shadowElement = container.querySelector('test-shadow');
+      shadowElement.setAttribute('id', 'shadow-host');
+      shadowElement.setAttribute('tabindex', 0);
+
+      const result = tabbable(shadowElement, {
+        getShadowRoot() {},
+        includeContainer: true,
+      });
+
+      expect(getIdsFromElementsArray(result)).to.eql(expected);
+    });
+
+    it('should sort slots inside shadow dom', () => {
+      const expected = [
+        'light-before',
+        'light-slotter-before',
+        'shadow-input',
+        'light-slotter-after',
+        'light-slotter-default',
+        'default-slot-input',
+        'light-after',
+      ];
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'light-shadow-with-slots',
+      });
+
+      const result = tabbable(container, { getShadowRoot() {} });
+
+      expect(getIdsFromElementsArray(result)).to.eql(expected);
+    });
+
+    it('should sort shadow and light elements separately', () => {
+      const expected = [
+        'light-first',
+        'light-middle',
+        'light-last',
+        'shadow-first',
+        'shadow-middle',
+        'shadow-last',
+      ];
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'light-shadow-tab-index',
+      });
+
+      const result = tabbable(container, { getShadowRoot() {} });
+
+      expect(getIdsFromElementsArray(result)).to.eql(expected);
+    });
+
+    it('should sort slots content by slots tabindex', () => {
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'slots-tab-index',
+      });
+
+      const tabbableList = tabbable(container, { getShadowRoot() {} });
+      const focusableList = focusable(container, { getShadowRoot() {} });
+
+      expect(getIdsFromElementsArray(tabbableList), 'tabbable').to.eql([
+        'light-1',
+        'shadow-1',
+        'shadow-2',
+        'light-2',
+        'shadow-3',
+        'light-3',
+      ]);
+      expect(getIdsFromElementsArray(focusableList), 'focusable').to.eql([
+        'shadow-3',
+        'light-3',
+        'light-2',
+        'light-1',
+        'shadow-2',
+        'shadow-1',
+      ]);
+    });
+
+    it('should insert slots nested content according to slot positions', () => {
+      const expected = [
+        'light-1',
+        'light-2',
+        'light-3',
+        'shadow-between',
+        'light-4',
+        'light-5',
+        'light-6',
+      ];
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'slots-nested-tab-index',
+      });
+
+      const result = tabbable(container, { getShadowRoot() {} });
+
+      expect(getIdsFromElementsArray(result)).to.eql(expected);
+    });
+
+    it('should query nested shadow doms for slots', () => {
+      const expected = [
+        'shadow-outter-before',
+        'shadow-inner',
+        'light-slotted-input',
+        'shadow-outter-after',
+      ];
+
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'slotted-through-multiple-shadows',
+      });
+
+      const result = tabbable(container, { getShadowRoot() {} });
+
+      expect(getIdsFromElementsArray(result)).to.eql(expected);
+    });
+
+    it('should find elements inside slot', () => {
+      const expected = ['light-slotter-before'];
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'light-shadow-with-slots',
+      });
+      const shadowElement = container.querySelector('test-shadow');
+      const slot = shadowElement.shadowRoot.querySelector(
+        'slot[name="before"]'
+      );
+
+      const result = tabbable(slot, { getShadowRoot() {} });
+
+      expect(getIdsFromElementsArray(result)).to.eql(expected);
+    });
+
+    it('should not find slot with tabindex', () => {
+      const expected = ['light-slotter-before'];
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'light-shadow-with-slots',
+      });
+      const shadowElement = container.querySelector('test-shadow');
+      const slot = shadowElement.shadowRoot.querySelector(
+        'slot[name="before"]'
+      );
+      slot.id = 'slot-id';
+      slot.tabIndex = '1';
+
+      const result = tabbable(slot, { getShadowRoot() {} });
+
+      expect(getIdsFromElementsArray(result)).to.eql(expected);
+    });
+
+    it('should filter un-tabbable elements', () => {
+      const expected = [
+        'shadow-summary',
+        'shadow-details-without-summary',
+        'shadow-radio-checked',
+      ];
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'filter-conditions',
+      });
+
+      const result = tabbable(container, { getShadowRoot() {} });
+
+      expect(getIdsFromElementsArray(result)).to.eql(expected);
+    });
+
+    it('should filter un-focusable elements', () => {
+      const expected = [
+        'shadow-summary',
+        'shadow-details-without-summary',
+        'shadow-radio-unchecked',
+        'shadow-radio-checked',
+        'shadow-negative-tabindex',
+      ];
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'filter-conditions',
+      });
+
+      const result = focusable(container, { getShadowRoot() {} });
+
+      expect(getIdsFromElementsArray(result)).to.eql(expected);
+    });
+
+    it('should accept shadow root in order to query closed shadows', () => {
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'closed-shadow-input',
+      });
+
+      const providedShadowRoot = tabbable(container, {
+        getShadowRoot(node) {
+          return node.closedShadowRoot;
+        },
+      });
+      const noKnowlageOfShadowRoot = tabbable(container, {
+        webComponents(_node) {
+          return false;
+        },
+      });
+      const unknownShadowRoot = tabbable(container, {
+        getShadowRoot(_node) {
+          return true;
+        },
+      });
+
+      expect(
+        getIdsFromElementsArray(providedShadowRoot),
+        'provided shadow root'
+      ).to.eql([
+        'light-before',
+        'shadow-input',
+        'light-slotted',
+        'light-after',
+      ]);
+      expect(
+        getIdsFromElementsArray(noKnowlageOfShadowRoot),
+        'no knowlage of shadow root'
+      ).to.eql(['light-slotted', 'light-before', 'light-after']);
+      expect(
+        getIdsFromElementsArray(unknownShadowRoot),
+        'unknown of shadow root'
+      ).to.eql(['light-before', 'light-slotted', 'light-after']);
     });
   });
 });

--- a/test/e2e/shadow-dom.e2e.js
+++ b/test/e2e/shadow-dom.e2e.js
@@ -43,5 +43,68 @@ describe('web-components', () => {
       expect(isTabbable(radio2Slotted), 'not checked slotted').to.eql(false);
       expect(isTabbable(lightRadio3), 'not checked in light').to.eql(false);
     });
+    it('should not match elements in shadow root with a "display=none" ancestor', () => {
+      const { container } = setupFixture(fixtures.shadowDomDisplay, {
+        window,
+        caseId: 'light-display-none',
+      });
+      const shadowRoot = container.querySelector('test-shadow').shadowRoot;
+      const shadowInput = shadowRoot.querySelector('#shadow-input');
+      const lightInputSlotted = container.querySelector('#light-input-slotted');
+
+      // focusable
+      expect(isFocusable(shadowInput), 'non display shadow').to.eql(false);
+      expect(isFocusable(lightInputSlotted), 'non display slotted').to.eql(
+        false
+      );
+      // tabbable
+      expect(isTabbable(shadowInput), 'non display shadow').to.eql(false);
+      expect(isTabbable(lightInputSlotted), 'non display slotted').to.eql(
+        false
+      );
+    });
+    it('should not match elements in a non display slot', () => {
+      const { container } = setupFixture(fixtures.shadowDomDisplay, {
+        window,
+        caseId: 'slot-display-none',
+      });
+      const lightInputSlotted = container.querySelector('#light-input-slotted');
+
+      expect(isFocusable(lightInputSlotted)).to.eql(false);
+      expect(isTabbable(lightInputSlotted)).to.eql(false);
+    });
+    it('should not match elements in a closed shadow root with inner display="none" (fallback to zero-area-size)', () => {
+      const { container } = setupFixture(fixtures.shadowDomDisplay, {
+        window,
+        caseId: 'slot-display-none-closed-shadow',
+      });
+      const webComp = container.querySelector('test-shadow');
+      const lightDisplayNoneSlotted = container.querySelector(
+        '#light-input-slotted'
+      );
+
+      // focusable
+      expect(
+        isFocusable(lightDisplayNoneSlotted),
+        'unable to test unknown shadow nested non display'
+      ).to.eql(true);
+      expect(
+        isFocusable(lightDisplayNoneSlotted, {
+          getShadowRoot: (node) => node === webComp,
+        }),
+        'fallback to zero size check for unreached shadow root'
+      ).to.eql(false);
+      // tabbable
+      expect(
+        isTabbable(lightDisplayNoneSlotted),
+        'unable to test unknown shadow nested non display'
+      ).to.eql(true);
+      expect(
+        isTabbable(lightDisplayNoneSlotted, {
+          getShadowRoot: (node) => node === webComp,
+        }),
+        'fallback to zero size for unreached shadow root'
+      ).to.eql(false);
+    });
   });
 });

--- a/test/e2e/shadow-dom.e2e.js
+++ b/test/e2e/shadow-dom.e2e.js
@@ -1,0 +1,47 @@
+import { isTabbable, isFocusable } from '../../src/index.js';
+import {
+  setupTestWindow,
+  removeAllChildNodes,
+  setupFixture,
+  getFixtures,
+} from './e2e.helpers';
+
+describe('web-components', () => {
+  let window, document, fixtures;
+  before(() => {
+    setupTestWindow((testWindow) => {
+      window = testWindow;
+      document = testWindow.document;
+    });
+    getFixtures((f) => (fixtures = f));
+  });
+
+  afterEach(() => {
+    removeAllChildNodes(document.body);
+  });
+
+  describe('isFocusable/isTabbable', () => {
+    it('should separate shadow/light radio button groups', () => {
+      const { container } = setupFixture(fixtures.shadowDomRadio, { window });
+      const shadowRoot = container.querySelector('#webComp').shadowRoot;
+      const shadowRadio1 = shadowRoot.querySelector('#shadow-radio1');
+      const shadowRadio2 = shadowRoot.querySelector('#shadow-radio2');
+      const lightRadio1 = container.querySelector('#light-radio1');
+      const radio2Slotted = container.querySelector('#light-radio2-slotted');
+      const lightRadio3 = container.querySelector('#light-radio3');
+
+      // always focusable
+      expect(isFocusable(shadowRadio1), 'checked in shadow').to.eql(true);
+      expect(isFocusable(shadowRadio2), 'not checked in shadow').to.eql(true);
+      expect(isFocusable(lightRadio1), 'checked in light').to.eql(true);
+      expect(isFocusable(radio2Slotted), 'not checked slotted').to.eql(true);
+      expect(isFocusable(lightRadio3), 'not checked in light').to.eql(true);
+      // only the first checked is tabbable
+      expect(isTabbable(shadowRadio1), 'checked in shadow').to.eql(true);
+      expect(isTabbable(shadowRadio2), 'not checked in shadow').to.eql(false);
+      expect(isTabbable(lightRadio1), 'checked in light').to.eql(true);
+      expect(isTabbable(radio2Slotted), 'not checked slotted').to.eql(false);
+      expect(isTabbable(lightRadio3), 'not checked in light').to.eql(false);
+    });
+  });
+});

--- a/test/e2e/shadow-dom.e2e.js
+++ b/test/e2e/shadow-dom.e2e.js
@@ -126,6 +126,23 @@ describe('web-components', () => {
       expect(getIdsFromElementsArray(result)).to.eql(expected);
     });
 
+    it('should find tabbable host', () => {
+      const expected = [
+        'light-before',
+        'tabbable-host',
+        'shadow-input',
+        'light-after',
+      ];
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'tabbable-host',
+      });
+
+      const result = tabbable(container, { getShadowRoot() {} });
+
+      expect(getIdsFromElementsArray(result)).to.eql(expected);
+    });
+
     it('should find elements inside shadow dom when directly querying the element with shadow root', () => {
       const expected = ['shadow-input'];
       const { container } = setupFixture(fixtures.shadowDomQuery, {

--- a/test/e2e/shadow-dom.e2e.js
+++ b/test/e2e/shadow-dom.e2e.js
@@ -112,6 +112,19 @@ describe('web-components', () => {
         'fallback to zero size for unreached shadow root'
       ).to.eql(false);
     });
+    it('should not match slot elements', () => {
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'slots-tab-index',
+      });
+      const shadowRoot = container.querySelector('test-shadow').shadowRoot;
+      const slotWithTabIndex = shadowRoot.querySelector(
+        'slot[name="slot-first"]'
+      );
+
+      expect(isFocusable(slotWithTabIndex), 'slot not focusable').to.eql(false);
+      expect(isTabbable(slotWithTabIndex), 'slot not tabbable').to.eql(false);
+    });
   });
   describe('query', () => {
     it('should find elements inside shadow dom', () => {

--- a/test/e2e/tabbable.e2e.js
+++ b/test/e2e/tabbable.e2e.js
@@ -2,6 +2,7 @@ import { tabbable } from '../../src/index.js';
 import {
   setupTestWindow,
   getFixtures,
+  setupFixture,
   removeAllChildNodes,
   getIdsFromElementsArray,
 } from './e2e.helpers';
@@ -290,17 +291,12 @@ describe('tabbable', () => {
     it('correctly identifies tabbable elements in the "shadow-dom" example', () => {
       const expectedTabbableIds = ['input'];
 
-      const container = document.createElement('div');
-      container.innerHTML = fixtures['shadow-dom'];
-      document.body.append(container);
+      const { container } = setupFixture(fixtures['shadow-dom'], { window });
+      const host = container.querySelector('test-shadow');
 
-      const host = container.querySelector('#shadow-host');
-      const template = container.querySelector('#shadow-root-template');
-
-      const shadow = host.attachShadow({ mode: 'open' });
-      shadow.appendChild(template.content.cloneNode(true));
-
-      const tabbableElements = tabbable(shadow.querySelector('#container'));
+      const tabbableElements = tabbable(
+        host.shadowRoot.querySelector('#container')
+      );
 
       expect(getIdsFromElementsArray(tabbableElements)).to.eql(
         expectedTabbableIds

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -32,4 +32,8 @@ module.exports = {
     path.join(__dirname, 'shadow-dom-display.html'),
     'utf8'
   ),
+  shadowDomQuery: fs.readFileSync(
+    path.join(__dirname, 'shadow-dom-query.html'),
+    'utf8'
+  ),
 };

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -28,4 +28,8 @@ module.exports = {
     path.join(__dirname, 'shadow-dom-radio.html'),
     'utf8'
   ),
+  shadowDomDisplay: fs.readFileSync(
+    path.join(__dirname, 'shadow-dom-display.html'),
+    'utf8'
+  ),
 };

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -24,4 +24,8 @@ module.exports = {
   ),
   displayed: fs.readFileSync(path.join(__dirname, 'displayed.html'), 'utf8'),
   fieldset: fs.readFileSync(path.join(__dirname, 'fieldset.html'), 'utf8'),
+  shadowDomRadio: fs.readFileSync(
+    path.join(__dirname, 'shadow-dom-radio.html'),
+    'utf8'
+  ),
 };

--- a/test/fixtures/shadow-dom-display.html
+++ b/test/fixtures/shadow-dom-display.html
@@ -1,0 +1,36 @@
+<div style="display:none;" id="light-display-none">
+    <h2>nested under display none in light dom</h2>
+    <test-shadow>
+        <template shadowroot="open">
+            <div>
+                <input id="shadow-input"></input>
+                <slot></slot>
+            </div>
+        </template>
+        <input id="light-input-slotted"></input>
+    </test-shadow>
+</div>
+
+<div id="slot-display-none">
+    <h2>"display=none" slot</h2>
+    <test-shadow>
+        <template shadowroot="open">
+            <div style="display:none;">
+                <slot></slot>
+            </div>
+        </template>
+        <input id="light-input-slotted"></input>
+    </test-shadow>
+</div>
+
+<div id="slot-display-none-closed-shadow">
+    <h2>"display=none" slot (mode=closed)</h2>
+    <test-shadow>
+        <template shadowroot="closed">
+            <div style="display:none;">
+                <slot></slot>
+            </div>
+        </template>
+        <input id="light-input-slotted"></input>
+    </test-shadow>
+</div>

--- a/test/fixtures/shadow-dom-query.html
+++ b/test/fixtures/shadow-dom-query.html
@@ -11,6 +11,19 @@
     <input id="light-after"></input>
 </div>
 
+<div id="tabbable-host">
+    <h2>tabbable host</h2>
+    <input id="light-before"></input>
+    <test-shadow tabindex="0" id="tabbable-host">
+        <template shadowroot="open">
+            <div>
+                <input id="shadow-input"></input>
+            </div>
+        </template>
+    </test-shadow>
+    <input id="light-after"></input>
+</div>
+
 <div id="light-shadow-with-slots">
     <h2>light shadow and slots</h2>
     <input id="light-before"></input>

--- a/test/fixtures/shadow-dom-query.html
+++ b/test/fixtures/shadow-dom-query.html
@@ -1,0 +1,139 @@
+<div id="shadow-input">
+    <h2>shadow input</h2>
+    <input id="light-before"></input>
+    <test-shadow>
+        <template shadowroot="open">
+            <div>
+                <input id="shadow-input"></input>
+            </div>
+        </template>
+    </test-shadow>
+    <input id="light-after"></input>
+</div>
+
+<div id="light-shadow-with-slots">
+    <h2>light shadow and slots</h2>
+    <input id="light-before"></input>
+    <test-shadow>
+        <template shadowroot="open">
+            <div>
+                <slot name="before"></slot>
+                <input id="shadow-input"></input>
+                <slot name="after"></slot>
+                <slot>
+                    <input id="default-slot-input-overridden"></input>
+                </slot>
+                <slot name="default-content">
+                    <input id="default-slot-input"></input>
+                </slot>
+            </div>
+        </template>
+        <input id="light-slotter-before" slot="before"></input>
+        <input id="light-slotter-after" slot="after"></input>
+        <input id="light-slotter-default"></input>
+    </test-shadow>
+    <input id="light-after"></input>
+</div>
+
+<div id="light-shadow-tab-index">
+    <h2>light shadow tab index</h2>
+    <input id="light-last"></input>
+    <test-shadow>
+        <template shadowroot="open">
+            <div>
+                <input id="shadow-middle" tabindex="2"></input>
+                <input id="shadow-last"></input>
+                <input id="shadow-first" tabindex="1"></input>
+            </div>
+        </template>
+    </test-shadow>
+    <input id="light-middle" tabindex="10"></input>
+    <input id="light-first" tabindex="5"></input>
+</div>
+
+<div id="slots-tab-index">
+    <h2>slots with tab index</h2>
+    <test-shadow>
+        <template shadowroot="open">
+            <input id="shadow-3"></input>
+            <slot name="slot-last"></slot>
+            <slot name="slot-middle" tabindex="3"></slot>
+            <slot name="slot-first" tabindex="1"></slot>
+            <input id="shadow-2" tabindex="2"></input>
+            <input id="shadow-1" tabindex="1"></input>
+        </template>
+        <input id="light-2" slot="slot-middle"></input>
+        <input id="light-3" slot="slot-last"></input>
+        <input id="light-1" slot="slot-first"></input>
+    </test-shadow>
+</div>
+
+<div id="slots-nested-tab-index">
+    <h2>slots with tab index</h2>
+    <test-shadow>
+        <template shadowroot="open">
+            <slot></slot>
+            <input id="shadow-between" tabindex="2"></input>
+            <slot name="first" tabindex="1"></slot>
+        </template>
+        <input id="light-6"></input>
+        <input id="light-5" tabindex="2"></input>
+        <input id="light-4" tabindex="1"></input>
+        <input id="light-3" slot="first"></input>
+        <input id="light-2" slot="first" tabindex="2"></input>
+        <input id="light-1" slot="first" tabindex="1"></input>
+    </test-shadow>
+</div>
+
+<div id="slotted-through-multiple-shadows">
+    <h2>slot through multiple nested shadow roots</h2>
+    <test-shadow>
+        <template shadowroot="open">
+            <input id="shadow-outter-before"></input>
+            <test-shadow>
+                <template shadowroot="open">
+                    <input id="shadow-inner"></input>
+                    <slot></slot>
+                </template>
+                <slot></slot>
+            </test-shadow>
+            <input id="shadow-outter-after"></input>
+        </template>
+        <input id="light-slotted-input"></input>
+    </test-shadow>
+</div>
+
+<div id="filter-conditions">
+    <h2>different conditions for filtering elements</h2>
+    <test-shadow>
+        <template shadowroot="open">
+            <input id="shadow-disabled" disabled></input>
+            <input id="shadow-type-hidden" type="hidden"></input>
+            <input id="shadow-visibility-hidden" style="visibility: hidden;"></input>
+            <input id="shadow-display-hidden" style="display: none;"></input>
+            <details>
+                <summary id="shadow-summary">un-opened details</summary>
+                <input id="shadow-unopned-details-hidden"></input>
+            </details>
+            <details id="shadow-details-without-summary"></details>
+            <input id="shadow-radio-unchecked" type="radio" name="group-a"></input>
+            <input id="shadow-radio-checked" type="radio" name="group-a" checked></input>
+            <input id="shadow-negative-tabindex" tabindex="-1"></input>
+        </template>
+    </test-shadow>
+</div>
+
+<div id="closed-shadow-input">
+    <h2>closed shadow input</h2>
+    <input id="light-before"></input>
+    <test-shadow>
+        <template shadowroot="closed">
+            <div>
+                <input id="shadow-input"></input>
+                <slot></slot>
+            </div>
+        </template>
+        <input id="light-slotted" tabindex="1"></input>
+    </test-shadow>
+    <input id="light-after"></input>
+</div>

--- a/test/fixtures/shadow-dom-radio.html
+++ b/test/fixtures/shadow-dom-radio.html
@@ -1,0 +1,16 @@
+<input type="radio" name="original-group" id="light-radio1" checked></input>
+<test-shadow id="webComp">
+    <template shadowroot="open">
+        <input type="radio" name="original-group" id="shadow-radio1" checked></input>
+        <input type="radio" name="original-group" id="shadow-radio2"></input>
+        <slot></slot>
+    </template>
+    <input type="radio" name="original-group" id="light-radio2-slotted"></input>
+</test-shadow>
+<input type="radio" name="original-group" id="light-radio3"></input>
+<style>
+    /*debug: mark light dom radios */
+    input[type="radio"][name="original-group"] {
+        outline: 1px solid blue;
+    }
+</style>

--- a/test/fixtures/shadow-dom.html
+++ b/test/fixtures/shadow-dom.html
@@ -1,7 +1,7 @@
-<div id="shadow-host"></div>
-
-<template id="shadow-root-template">
-  <div id="container">
-    <input id="input" type="text" />
-  </div>
-</template>
+<test-shadow>
+  <template shadowroot="open">
+    <div id="container">
+      <input id="input" type="text" />
+    </div>
+  </template>
+</test-shadow>

--- a/test/shadow-root-utils.js
+++ b/test/shadow-root-utils.js
@@ -1,0 +1,76 @@
+function supportsDeclarativeShadowDOM() {
+  // eslint-disable-next-line no-prototype-builtins
+  return HTMLTemplateElement.prototype.hasOwnProperty('shadowRoot');
+}
+
+function hydrateShadowDomPolyfill(template) {
+  const mode = template.getAttribute('shadowroot');
+  const delegatesFocus = !!template.getAttribute('shadowrootdelegatesfocus');
+  const host = template.parentNode;
+  const shadowRoot = host.attachShadow({ mode, delegatesFocus });
+  // expose closed shadow root for tests
+  if (mode === 'closed') {
+    host.closedShadowRoot = shadowRoot;
+  }
+  shadowRoot.appendChild(template.content);
+  template.remove();
+}
+
+function scanAndHydrateShadowDom(container) {
+  container
+    .querySelectorAll('template[shadowroot]')
+    .forEach(hydrateShadowDomPolyfill);
+}
+
+function defineCustomTestElement(win) {
+  // register custom element to expose closed shadow for tests
+  if (!win.customElements.get('test-shadow')) {
+    win.customElements.define(
+      'test-shadow',
+      class TestShadow extends win.HTMLElement {
+        constructor() {
+          super();
+          if (supportsDeclarativeShadowDOM()) {
+            // expose closed shadow root for tests
+            const { shadowRoot } = this.attachInternals();
+            if (shadowRoot.mode === 'closed') {
+              this.closedShadowRoot = shadowRoot;
+            }
+          } else {
+            // polyfill nested shadow hydration
+            const shadowRoot = this.shadowRoot || this.closedShadowRoot;
+            if (shadowRoot) {
+              scanAndHydrateShadowDom(shadowRoot);
+            }
+          }
+        }
+      }
+    );
+  }
+}
+
+exports.appendHTMLWithShadowRoots = function (
+  container,
+  content,
+  { win, caseId } = {}
+) {
+  win = win || window;
+  defineCustomTestElement(win);
+  // create dom fragments with shadow dom (if supported)
+  const fragment = new win.DOMParser().parseFromString(content, 'text/html', {
+    includeShadowRoots: true,
+  });
+  // append content
+  if (caseId) {
+    container.appendChild(fragment.querySelector('#' + caseId));
+  } else {
+    const nodes = fragment.children[0].children[1].children;
+    while (nodes.length) {
+      container.appendChild(nodes[0]);
+    }
+  }
+  // polyfill shadow hydration if not supported
+  if (supportsDeclarativeShadowDOM() === false) {
+    scanAndHydrateShadowDom(container);
+  }
+};


### PR DESCRIPTION
This PR adds support for shadow dom (as requested in #50). Currently I just placed all tests in a single e2e spec, because it was much easier to handle, I will probably break it down into the 4 apis before we merge. The code is separated into 2 parts:

1. changes to check isTabbable/isFocusable
2. alternative to dom query which walks the dom 

new options API:
- getShadowRoot(element): called for any element without `shadowRoot` property in order to detect shadow dom. (return `shadowRoot` in order to query internally, `true` to indicate there is a shadow-root, but it's not available or `false` for no shadow-root)

- [x] dev support for fixtures with [declarative shadow dom](https://web.dev/declarative-shadow-dom/):
    - add development shadow-root-utils to handle hydration, polyfill and expose closed shadow root for tests.
    - add options to render a subtree of a fixture `setupFixture(content, {**caseId**})`.
    - change debug page to include and work with shadow dom examples.
- support isTabbable/isFocusable:
    - [x] separate radio buttons group between each light/shadow (found [unexpected behavior](https://bugs.chromium.org/p/chromium/issues/detail?id=1200261) in chromium).
    - [x] check for display in shadow dom and across shadow boundary when possible:
        - if a shadow root is detected, but cannot be accessed, then fallback to zero-size display check.
        - **caveat**: if an element, or one of it's ancestors, is nested under an undetected shadow-root with `display=none` or is not slotted, then the element will be wrongly considered focusable (only for `displayCheck: "full"`).
- [x] support scanning dom via walking instead of query
    - when `getShadowRoot` option is supplied then walking is picked over query and shadow-roots and slots are visited
    - new type of candidate list with scoped items is supported. a scope item is not a tabbable/focusable item by itself, but contains a list of nested elements that needs to be sorted between themselves and inserted according to the scoped item computed position (shadow-roots and slots generates scoped items, while shadow hosts can also be focusable/tabbable themselves).
    - sort now accepts the new scoped candidate list, sort and flatten it.
- `delegatesFocus` is not implemented here.
    - ~I played with it, but it only works in chromium (can't get it to [work on Firefox](https://bug-166484-attachments.webkit.org/attachment.cgi?id=297772), although MDN states [differently](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus#browser_compatibility)), and in any case it's marked as [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus)~ [not implemented](https://bugzilla.mozilla.org/show_bug.cgi?id=1706275) in Firefox
    - if this were to be added then it's simply a matter of adding a check in `isTabbable/isFocusable`. The check try to find `shadowRoot.delegatesFocus` (currently exposed on chromium), or ask for `options.delegatesFocus(node)` and allow whoever uses Tabbable to provide the flag according to available shadow knowledge and  browser support.
    - added support for `shadowrootdelegatesfocus` in the declarative shadow dom dev utils for now
- [x] types
- [ ] documentation -  README updated (API changes, instructions, etc.).
- [ ] make sure source is compatible with the acceptable ECMAScript version
- [ ] Changeset
    
Some thoughts:
- closed mode shadow roots cannot be accessed without help from whoever defined them. This can be solved with a component framework/platform or apparently anyone with access to the page before the components are defined by overriding `customElements.define` or `Element.prototype.attachShadow` 🤔
- it might be helpful to offer a way to mark dom elements and run a query instead of walking, but that's just optimizations features that can be added later.
- now that there is an iterative dom walk option, iframes content can be scanned in a similar way.
- change debug page to render one fixture/fixture case at a time, currently tabindex between fixtures make it hard to use.
- maybe change source to latest ECMAScript to clean it up and just transpile for legacy versions.
- also it would be nice to break down the source into separate files as its hard to navigate through.

