### PR TITLE
Avoid FF hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         browser: [chrome, firefox]
     container:
       image: cypress/included:7.1.0
-      options: --user 1001
+      options: --user 1001 --shm-size=2g # @see https://github.com/cypress-io/github-action/issues/104#issuecomment-666047965
     env:
       CYPRESS_BROWSER: ${{ matrix.browser }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
     strategy:
       matrix:
         browser: [chrome, firefox]
+    timeout-minutes: 20
     container:
       image: cypress/included:7.1.0
       options: --user 1001 --shm-size=2g # @see https://github.com/cypress-io/github-action/issues/104#issuecomment-666047965


### PR DESCRIPTION
Firefox may hang in CI when running Cypress tests. Increasing shared memory helps to avoid this. Also added timeout just to be sure since default is 6 hours, which unnecessarily burns CI minutes.