### PR TITLE
fix(index.js): fixed bug in 'isDisabledFromFieldset' (fixes #596)

### DIFF
--- a/.changeset/long-planets-sleep.md
+++ b/.changeset/long-planets-sleep.md
@@ -1,0 +1,5 @@
+---
+'tabbable': patch
+---
+
+Fixed bug in `isDisabledFromFieldset`. The function wasn't checking whether the disabled <fieldset> containing `node` is the top-most disabled <fieldset>.

--- a/.changeset/long-planets-sleep.md
+++ b/.changeset/long-planets-sleep.md
@@ -2,4 +2,4 @@
 'tabbable': patch
 ---
 
-Fixed bug in `isDisabledFromFieldset`. The function wasn't checking whether the disabled <fieldset> containing `node` is the top-most disabled <fieldset>.
+Fixed bug in `isDisabledFromFieldset`. The function wasn't checking whether the disabled `<fieldset>` containing `node` is the top-most disabled `<fieldset>` ([#596](https://github.com/focus-trap/tabbable/issues/596)).

--- a/src/index.js
+++ b/src/index.js
@@ -173,19 +173,26 @@ const isDisabledFromFieldset = function (node) {
     let parentNode = node.parentElement;
     while (parentNode) {
       if (parentNode.tagName === 'FIELDSET' && parentNode.disabled) {
-        // look for the first <legend> as an immediate child of the disabled
-        //  <fieldset>: if the node is in that legend, it'll be enabled even
-        //  though the fieldset is disabled; otherwise, the node is in a
-        //  secondary/subsequent legend, or somewhere else within the fieldset
-        //  (however deep nested) and it'll be disabled
+        // look for the first <legend> among the children of the disabled <fieldset>
         for (let i = 0; i < parentNode.children.length; i++) {
           const child = parentNode.children.item(i);
+          // when the first <legend> (in document order) is found
           if (child.tagName === 'LEGEND') {
-            // return whether `node` is a descendant of the first <legend> found
+            // check whether the <fieldset> containing `node` is the top-most disabled <fieldset>
+            let ancestor = parentNode.parentElement;
+            while (ancestor) {
+              if (ancestor.tagName === 'FIELDSET' && ancestor.disabled) {
+                // the disabled <fieldset> containing `node` is nested in another disabled <fieldset>
+                return true;
+              }
+              ancestor = ancestor.parentElement;
+            }
+            // the disabled <fieldset> containing `node` is the the top-most disabled <fieldset>,
+            // so return whether `node` is a descendant of its first <legend>
             return !child.contains(node);
           }
         }
-        // the disabled <fieldset> containing the `node` has no <legend> at all
+        // the disabled <fieldset> containing `node` has no <legend>
         return true;
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -173,7 +173,6 @@ const isDisabledFromFieldset = function (node) {
     let parentNode = node.parentElement;
     // check if `node` is contained in a disabled <fieldset>
     while (parentNode) {
-      // if it is
       if (parentNode.tagName === 'FIELDSET' && parentNode.disabled) {
         // look for the first <legend> among the children of the disabled <fieldset>
         for (let i = 0; i < parentNode.children.length; i++) {
@@ -182,9 +181,8 @@ const isDisabledFromFieldset = function (node) {
           if (child.tagName === 'LEGEND') {
             // check whether its parent <fieldset> is nested in another disabled <fieldset>
             while ((parentNode = parentNode.parentElement)) {
-              // if it is
               if (parentNode.tagName === 'FIELDSET' && parentNode.disabled) {
-                // then the node is not in the <legend> of the top-most disabled <fieldset>
+                // the node is not in the <legend> of the top-most disabled <fieldset>
                 return true;
               }
             }

--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,7 @@ const isDisabledFromFieldset = function (node) {
             // check whether its parent <fieldset> is nested in another disabled <fieldset>
             while ((parentNode = parentNode.parentElement)) {
               if (parentNode.tagName === 'FIELDSET' && parentNode.disabled) {
-                // the node is not in the <legend> of the top-most disabled <fieldset>
+                // the disabled <fieldset> containing `node` is not the top-most disabled <fieldset>
                 return true;
               }
             }

--- a/src/index.js
+++ b/src/index.js
@@ -171,21 +171,22 @@ const isHidden = function (node, displayCheck) {
 const isDisabledFromFieldset = function (node) {
   if (/^(INPUT|BUTTON|SELECT|TEXTAREA)$/.test(node.tagName)) {
     let parentNode = node.parentElement;
+    // check if `node` is contained in a disabled <fieldset>
     while (parentNode) {
+      // if it is
       if (parentNode.tagName === 'FIELDSET' && parentNode.disabled) {
         // look for the first <legend> among the children of the disabled <fieldset>
         for (let i = 0; i < parentNode.children.length; i++) {
           const child = parentNode.children.item(i);
           // when the first <legend> (in document order) is found
           if (child.tagName === 'LEGEND') {
-            // check whether the <fieldset> containing `node` is the top-most disabled <fieldset>
-            let ancestor = parentNode.parentElement;
-            while (ancestor) {
-              if (ancestor.tagName === 'FIELDSET' && ancestor.disabled) {
-                // the disabled <fieldset> containing `node` is nested in another disabled <fieldset>
+            // check whether its parent <fieldset> is nested in another disabled <fieldset>
+            while ((parentNode = parentNode.parentElement)) {
+              // if it is
+              if (parentNode.tagName === 'FIELDSET' && parentNode.disabled) {
+                // then the node is not in the <legend> of the top-most disabled <fieldset>
                 return true;
               }
-              ancestor = ancestor.parentElement;
             }
             // the disabled <fieldset> containing `node` is the the top-most disabled <fieldset>,
             // so return whether `node` is a descendant of its first <legend>
@@ -195,7 +196,6 @@ const isDisabledFromFieldset = function (node) {
         // the disabled <fieldset> containing `node` has no <legend>
         return true;
       }
-
       parentNode = parentNode.parentElement;
     }
   }

--- a/test/e2e/isFocusable.e2e.js
+++ b/test/e2e/isFocusable.e2e.js
@@ -331,6 +331,10 @@ describe('isFocusable', () => {
     <legend><button data-testid="fieldset-disabled-fieldset-enabled-legend-button">Button not tabbable/focusable</button></legend>
     <input data-testid="fieldset-disabled-fieldset-enabled-input" type="text" value="Input not tabbable/focusable">
   </fieldset>
+  <fieldset data-testid="fieldset-disabled-fieldset-disabled" disabled>
+    <legend><button data-testid="fieldset-disabled-fieldset-disabled-legend-button">Button not tabbable/focusable</button></legend>
+    <input data-testid="fieldset-disabled-fieldset-disabled-input" type="text" value="Input not tabbable/focusable" />
+  </fieldset>
   <a data-testid="fieldset-disabled-anchor" href="#">Link is tabbable/focusable</a>
 </fieldset>
 `;
@@ -393,6 +397,21 @@ describe('isFocusable', () => {
       expect(
         isFocusable(
           getByTestId(container, 'fieldset-disabled-fieldset-enabled-input')
+        )
+      ).to.eql(false);
+
+      // nested in disabled fieldset, top-most disabled fieldset takes precedence
+      expect(
+        isFocusable(
+          getByTestId(
+            container,
+            'fieldset-disabled-fieldset-disabled-legend-button'
+          )
+        )
+      ).to.eql(false);
+      expect(
+        isFocusable(
+          getByTestId(container, 'fieldset-disabled-fieldset-disabled-input')
         )
       ).to.eql(false);
 

--- a/test/e2e/isFocusable.e2e.js
+++ b/test/e2e/isFocusable.e2e.js
@@ -1,13 +1,18 @@
 import { isFocusable } from '../../src/index.js';
-import { setupTestWindow, removeAllChildNodes } from './e2e.helpers';
+import {
+  setupTestWindow,
+  getFixtures,
+  removeAllChildNodes,
+} from './e2e.helpers';
 const { getByTestId, getByText } = require('@testing-library/dom');
 
 describe('isFocusable', () => {
-  let document;
+  let document, fixtures;
   before(() => {
     setupTestWindow((testWindow) => {
       document = testWindow.document;
     });
+    getFixtures((f) => (fixtures = f));
   });
 
   afterEach(() => {
@@ -301,43 +306,10 @@ describe('isFocusable', () => {
 
     it('returns false for any form element inside a disabled fieldset', () => {
       const container = document.createElement('div');
-      container.innerHTML = `
-<fieldset data-testid="fieldset-disabled" disabled>
-  <legend data-testid="fieldset-disabled-legend1">
-    Disabled fieldset legend 1 (all ENABLED)
-    <button data-testid="fieldset-disabled-legend1-button">Button is tabbable/focusable</button>
-    <input data-testid="fieldset-disabled-legend1-input" type="text" value="Input is tabbable/focusable">
-    <select data-testid="fieldset-disabled-legend1-select">
-      <option value="foo">Select is tabbable/focusable</option>
-    </select>
-    <textarea data-testid="fieldset-disabled-legend1-textarea" cols="30" rows="10">Textarea is tabbable/focusable</textarea>
-  </legend>
-  <legend data-testid="fieldset-disabled-legend2">
-    Disabled fieldset legend 2 (all disabled)
-    <button data-testid="fieldset-disabled-legend2-button">Button not tabbable/focusable</button>
-    <input data-testid="fieldset-disabled-legend2-input" type="text" value="Input not tabbable/focusable">
-    <select data-testid="fieldset-disabled-legend2-select">
-      <option value="foo">Select not tabbable/focusable</option>
-    </select>
-    <textarea data-testid="fieldset-disabled-legend2-textarea" cols="30" rows="10">Textarea not tabbable/focusable</textarea>
-  </legend>
-  <button data-testid="fieldset-disabled-button">Button not tabbable/focusable</button>
-  <input data-testid="fieldset-disabled-input" type="text" value="Input not tabbable/focusable">
-  <select data-testid="fieldset-disabled-select">
-    <option value="foo">Select not tabbable/focusable</option>
-  </select>
-  <textarea data-testid="fieldset-disabled-textarea" cols="30" rows="10">Textarea not tabbable/focusable</textarea>
-  <fieldset data-testid="fieldset-disabled-fieldset-enabled">
-    <legend><button data-testid="fieldset-disabled-fieldset-enabled-legend-button">Button not tabbable/focusable</button></legend>
-    <input data-testid="fieldset-disabled-fieldset-enabled-input" type="text" value="Input not tabbable/focusable">
-  </fieldset>
-  <fieldset data-testid="fieldset-disabled-fieldset-disabled" disabled>
-    <legend><button data-testid="fieldset-disabled-fieldset-disabled-legend-button">Button not tabbable/focusable</button></legend>
-    <input data-testid="fieldset-disabled-fieldset-disabled-input" type="text" value="Input not tabbable/focusable" />
-  </fieldset>
-  <a data-testid="fieldset-disabled-anchor" href="#">Link is tabbable/focusable</a>
-</fieldset>
-`;
+      container.innerHTML = fixtures.fieldset.replaceAll(
+        'id="',
+        'data-testid="'
+      );
       document.body.append(container);
 
       // in first legend of disabled fieldset: focusable

--- a/test/e2e/isTabbable.e2e.js
+++ b/test/e2e/isTabbable.e2e.js
@@ -322,6 +322,10 @@ describe('isTabbable', () => {
     <legend><button data-testid="fieldset-disabled-fieldset-enabled-legend-button">Button not tabbable/focusable</button></legend>
     <input data-testid="fieldset-disabled-fieldset-enabled-input" type="text" value="Input not tabbable/focusable">
   </fieldset>
+  <fieldset data-testid="fieldset-disabled-fieldset-disabled" disabled>
+    <legend><button data-testid="fieldset-disabled-fieldset-disabled-legend-button">Button not tabbable/focusable</button></legend>
+    <input data-testid="fieldset-disabled-fieldset-disabled-input" type="text" value="Input not tabbable/focusable" />
+  </fieldset>
   <a data-testid="fieldset-disabled-anchor" href="#">Link is tabbable/focusable</a>
 </fieldset>
 `;
@@ -369,6 +373,21 @@ describe('isTabbable', () => {
       ).to.eql(false);
 
       // nested in enabled fieldset, disabled parent fieldset takes precedence
+      expect(
+        isTabbable(
+          getByTestId(
+            container,
+            'fieldset-disabled-fieldset-enabled-legend-button'
+          )
+        )
+      ).to.eql(false);
+      expect(
+        isTabbable(
+          getByTestId(container, 'fieldset-disabled-fieldset-enabled-input')
+        )
+      ).to.eql(false);
+
+      // nested in enabled fieldset, top-most disabled fieldset takes precedence
       expect(
         isTabbable(
           getByTestId(

--- a/test/e2e/isTabbable.e2e.js
+++ b/test/e2e/isTabbable.e2e.js
@@ -1,13 +1,18 @@
 import { isTabbable } from '../../src/index.js';
-import { setupTestWindow, removeAllChildNodes } from './e2e.helpers';
+import {
+  setupTestWindow,
+  getFixtures,
+  removeAllChildNodes,
+} from './e2e.helpers';
 const { getByTestId, getByText } = require('@testing-library/dom');
 
 describe('isTabbable', () => {
-  let document;
+  let document, fixtures;
   before(() => {
     setupTestWindow((testWindow) => {
       document = testWindow.document;
     });
+    getFixtures((f) => (fixtures = f));
   });
 
   afterEach(() => {
@@ -292,43 +297,10 @@ describe('isTabbable', () => {
 
     it('returns false for any form element inside a disabled fieldset', () => {
       const container = document.createElement('div');
-      container.innerHTML = `
-<fieldset data-testid="fieldset-disabled" disabled>
-  <legend data-testid="fieldset-disabled-legend1">
-    Disabled fieldset legend 1 (all ENABLED)
-    <button data-testid="fieldset-disabled-legend1-button">Button is tabbable/focusable</button>
-    <input data-testid="fieldset-disabled-legend1-input" type="text" value="Input is tabbable/focusable">
-    <select data-testid="fieldset-disabled-legend1-select">
-      <option value="foo">Select is tabbable/focusable</option>
-    </select>
-    <textarea data-testid="fieldset-disabled-legend1-textarea" cols="30" rows="10">Textarea is tabbable/focusable</textarea>
-  </legend>
-  <legend data-testid="fieldset-disabled-legend2">
-    Disabled fieldset legend 2 (all disabled)
-    <button data-testid="fieldset-disabled-legend2-button">Button not tabbable/focusable</button>
-    <input data-testid="fieldset-disabled-legend2-input" type="text" value="Input not tabbable/focusable">
-    <select data-testid="fieldset-disabled-legend2-select">
-      <option value="foo">Select not tabbable/focusable</option>
-    </select>
-    <textarea data-testid="fieldset-disabled-legend2-textarea" cols="30" rows="10">Textarea not tabbable/focusable</textarea>
-  </legend>
-  <button data-testid="fieldset-disabled-button">Button not tabbable/focusable</button>
-  <input data-testid="fieldset-disabled-input" type="text" value="Input not tabbable/focusable">
-  <select data-testid="fieldset-disabled-select">
-    <option value="foo">Select not tabbable/focusable</option>
-  </select>
-  <textarea data-testid="fieldset-disabled-textarea" cols="30" rows="10">Textarea not tabbable/focusable</textarea>
-  <fieldset data-testid="fieldset-disabled-fieldset-enabled">
-    <legend><button data-testid="fieldset-disabled-fieldset-enabled-legend-button">Button not tabbable/focusable</button></legend>
-    <input data-testid="fieldset-disabled-fieldset-enabled-input" type="text" value="Input not tabbable/focusable">
-  </fieldset>
-  <fieldset data-testid="fieldset-disabled-fieldset-disabled" disabled>
-    <legend><button data-testid="fieldset-disabled-fieldset-disabled-legend-button">Button not tabbable/focusable</button></legend>
-    <input data-testid="fieldset-disabled-fieldset-disabled-input" type="text" value="Input not tabbable/focusable" />
-  </fieldset>
-  <a data-testid="fieldset-disabled-anchor" href="#">Link is tabbable/focusable</a>
-</fieldset>
-`;
+      container.innerHTML = fixtures.fieldset.replaceAll(
+        'id="',
+        'data-testid="'
+      );
       document.body.append(container);
 
       // in first legend of disabled fieldset: tabbable

--- a/test/fixtures/fieldset.html
+++ b/test/fixtures/fieldset.html
@@ -1,130 +1,70 @@
 <button id="free-enabled-button">button</button>
 <button id="free-disabled-button" disabled>disabled button</button>
 <div id="testcontainer">
-  <fieldset id="fieldset-enabled">
-    <legend id="fieldset-enabled-legend">
-      Enabled fieldset legend
-      <button id="fieldset-enabled-legend-button"
-        >Button is tabbable/focusable</button
-      >
-      <input
-        id="fieldset-enabled-legend-input"
-        type="text"
-        value="Input is tabbable/focusable"
-      />
-      <select id="fieldset-enabled-legend-select">
-        <option value="foo">Select is tabbable/focusable</option>
-      </select>
-      <textarea id="fieldset-enabled-legend-textarea" cols="30" rows="10">
-Textarea is tabbable/focusable</textarea
-      >
-    </legend>
-
-    <button id="fieldset-enabled-button">Button is tabbable/focusable</button>
-    <input
-      id="fieldset-enabled-input"
-      type="text"
-      value="Input is tabbable/focusable"
-    />
-    <select id="fieldset-enabled-select">
+<fieldset id="fieldset-enabled">
+  <legend id="fieldset-enabled-legend">
+    Enabled fieldset legend
+    <button id="fieldset-enabled-legend-button">Button is tabbable/focusable</button>
+    <input id="fieldset-enabled-legend-input" type="text" value="Input is tabbable/focusable">
+    <select id="fieldset-enabled-legend-select">
       <option value="foo">Select is tabbable/focusable</option>
     </select>
-    <textarea id="fieldset-enabled-textarea" cols="30" rows="10">
-Textarea is tabbable/focusable</textarea
-    >
+    <textarea id="fieldset-enabled-legend-textarea" cols="30" rows="10">Textarea is tabbable/focusable</textarea>
+  </legend>
 
-    <fieldset disabled id="fieldset-enabled-fieldset-disabled">
-      <legend
-        ><button id="fieldset-enabled-fieldset-disabled-legend-button"
-          >Button is tabbable/focusable</button
-        ></legend
-      >
-      <input
-        id="fieldset-enabled-fieldset-disabled-input"
-        type="text"
-        value="Input not tabbable/focusable"
-      />
-    </fieldset>
+  <button id="fieldset-enabled-button">Button is tabbable/focusable</button>
+  <input id="fieldset-enabled-input" type="text" value="Input is tabbable/focusable">
+  <select id="fieldset-enabled-select">
+    <option value="foo">Select is tabbable/focusable</option>
+  </select>
+  <textarea id="fieldset-enabled-textarea" cols="30" rows="10">Textarea is tabbable/focusable</textarea>
 
-    <a id="fieldset-enabled-anchor" href="#">Link is tabbable/focusable</a>
+  <fieldset disabled id="fieldset-enabled-fieldset-disabled">
+    <legend><button id="fieldset-enabled-fieldset-disabled-legend-button">Button is tabbable/focusable</button></legend>
+    <input id="fieldset-enabled-fieldset-disabled-input" type="text" value="Input not tabbable/focusable" />
   </fieldset>
 
-  <fieldset id="fieldset-disabled" disabled>
-    <legend id="fieldset-disabled-legend1">
-      Disabled fieldset legend 1 (all ENABLED)
-      <button id="fieldset-disabled-legend1-button"
-        >Button is tabbable/focusable</button
-      >
-      <input
-        id="fieldset-disabled-legend1-input"
-        type="text"
-        value="Input is tabbable/focusable"
-      />
-      <select id="fieldset-disabled-legend1-select">
-        <option value="foo">Select is tabbable/focusable</option>
-      </select>
-      <textarea id="fieldset-disabled-legend1-textarea" cols="30" rows="10">
-Textarea is tabbable/focusable</textarea
-      >
-    </legend>
+  <a id="fieldset-enabled-anchor" href="#">Link is tabbable/focusable</a>
+</fieldset>
 
-    <legend id="fieldset-disabled-legend2">
-      Disabled fieldset legend 2 (all disabled)
-      <button id="fieldset-disabled-legend2-button"
-        >Button not tabbable/focusable</button
-      >
-      <input
-        id="fieldset-disabled-legend2-input"
-        type="text"
-        value="Input not tabbable/focusable"
-      />
-      <select id="fieldset-disabled-legend2-select">
-        <option value="foo">Select not tabbable/focusable</option>
-      </select>
-      <textarea id="fieldset-disabled-legend2-textarea" cols="30" rows="10">
-Textarea not tabbable/focusable</textarea
-      >
-    </legend>
+<fieldset id="fieldset-disabled" disabled>
+  <legend id="fieldset-disabled-legend1">
+    Disabled fieldset legend 1 (all ENABLED)
+    <button id="fieldset-disabled-legend1-button">Button is tabbable/focusable</button>
+    <input id="fieldset-disabled-legend1-input" type="text" value="Input is tabbable/focusable">
+    <select id="fieldset-disabled-legend1-select">
+      <option value="foo">Select is tabbable/focusable</option>
+    </select>
+    <textarea id="fieldset-disabled-legend1-textarea" cols="30" rows="10">Textarea is tabbable/focusable</textarea>
+  </legend>
 
-    <button id="fieldset-disabled-button">Button not tabbable/focusable</button>
-    <input
-      id="fieldset-disabled-input"
-      type="text"
-      value="Input not tabbable/focusable"
-    />
-    <select id="fieldset-disabled-select">
+  <legend id="fieldset-disabled-legend2">
+    Disabled fieldset legend 2 (all disabled)
+    <button id="fieldset-disabled-legend2-button">Button not tabbable/focusable</button>
+    <input id="fieldset-disabled-legend2-input" type="text" value="Input not tabbable/focusable">
+    <select id="fieldset-disabled-legend2-select">
       <option value="foo">Select not tabbable/focusable</option>
     </select>
-    <textarea id="fieldset-disabled-textarea" cols="30" rows="10">
-Textarea not tabbable/focusable</textarea
-    >
+    <textarea id="fieldset-disabled-legend2-textarea" cols="30" rows="10">Textarea not tabbable/focusable</textarea>
+  </legend>
 
-    <fieldset id="fieldset-disabled-fieldset-enabled">
-      <legend
-        ><button id="fieldset-disabled-fieldset-enabled-legend-button"
-          >Button not tabbable/focusable</button
-        ></legend
-      >
-      <input
-        id="fieldset-disabled-fieldset-enabled-input"
-        type="text"
-        value="Input not tabbable/focusable"
-      />
-    </fieldset>
+  <button id="fieldset-disabled-button">Button not tabbable/focusable</button>
+  <input id="fieldset-disabled-input" type="text" value="Input not tabbable/focusable">
+  <select id="fieldset-disabled-select">
+    <option value="foo">Select not tabbable/focusable</option>
+  </select>
+  <textarea id="fieldset-disabled-textarea" cols="30" rows="10">Textarea not tabbable/focusable</textarea>
 
-    <fieldset id="fieldset-disabled-fieldset-disabled" disabled>
-      <legend
-        ><button id="fieldset-disabled-fieldset-disabled-legend-button"
-          >Button not tabbable/focusable</button
-        ></legend
-      >
-      <input
-        id="fieldset-disabled-fieldset-disabled-input"
-        type="text"
-        value="Input not tabbable/focusable"
-      />
-    </fieldset>
-
-    <a id="fieldset-disabled-anchor" href="#">Link is tabbable/focusable</a>
+  <fieldset id="fieldset-disabled-fieldset-enabled">
+    <legend><button id="fieldset-disabled-fieldset-enabled-legend-button">Button not tabbable/focusable</button></legend>
+    <input id="fieldset-disabled-fieldset-enabled-input" type="text" value="Input not tabbable/focusable" />
   </fieldset>
+
+  <fieldset id="fieldset-disabled-fieldset-disabled" disabled>
+    <legend><button id="fieldset-disabled-fieldset-disabled-legend-button">Button not tabbable/focusable</button></legend>
+    <input id="fieldset-disabled-fieldset-disabled-input" type="text" value="Input not tabbable/focusable" />
+  </fieldset>
+
+  <a id="fieldset-disabled-anchor" href="#">Link is tabbable/focusable</a>
+</fieldset>
 </div>

--- a/test/fixtures/fieldset.html
+++ b/test/fixtures/fieldset.html
@@ -1,65 +1,130 @@
 <button id="free-enabled-button">button</button>
 <button id="free-disabled-button" disabled>disabled button</button>
 <div id="testcontainer">
-<fieldset id="fieldset-enabled">
-  <legend id="fieldset-enabled-legend">
-    Enabled fieldset legend
-    <button id="fieldset-enabled-legend-button">Button is tabbable/focusable</button>
-    <input id="fieldset-enabled-legend-input" type="text" value="Input is tabbable/focusable">
-    <select id="fieldset-enabled-legend-select">
+  <fieldset id="fieldset-enabled">
+    <legend id="fieldset-enabled-legend">
+      Enabled fieldset legend
+      <button id="fieldset-enabled-legend-button"
+        >Button is tabbable/focusable</button
+      >
+      <input
+        id="fieldset-enabled-legend-input"
+        type="text"
+        value="Input is tabbable/focusable"
+      />
+      <select id="fieldset-enabled-legend-select">
+        <option value="foo">Select is tabbable/focusable</option>
+      </select>
+      <textarea id="fieldset-enabled-legend-textarea" cols="30" rows="10">
+Textarea is tabbable/focusable</textarea
+      >
+    </legend>
+
+    <button id="fieldset-enabled-button">Button is tabbable/focusable</button>
+    <input
+      id="fieldset-enabled-input"
+      type="text"
+      value="Input is tabbable/focusable"
+    />
+    <select id="fieldset-enabled-select">
       <option value="foo">Select is tabbable/focusable</option>
     </select>
-    <textarea id="fieldset-enabled-legend-textarea" cols="30" rows="10">Textarea is tabbable/focusable</textarea>
-  </legend>
+    <textarea id="fieldset-enabled-textarea" cols="30" rows="10">
+Textarea is tabbable/focusable</textarea
+    >
 
-  <button id="fieldset-enabled-button">Button is tabbable/focusable</button>
-  <input id="fieldset-enabled-input" type="text" value="Input is tabbable/focusable">
-  <select id="fieldset-enabled-select">
-    <option value="foo">Select is tabbable/focusable</option>
-  </select>
-  <textarea id="fieldset-enabled-textarea" cols="30" rows="10">Textarea is tabbable/focusable</textarea>
+    <fieldset disabled id="fieldset-enabled-fieldset-disabled">
+      <legend
+        ><button id="fieldset-enabled-fieldset-disabled-legend-button"
+          >Button is tabbable/focusable</button
+        ></legend
+      >
+      <input
+        id="fieldset-enabled-fieldset-disabled-input"
+        type="text"
+        value="Input not tabbable/focusable"
+      />
+    </fieldset>
 
-  <fieldset disabled id="fieldset-enabled-fieldset-disabled">
-    <legend><button id="fieldset-enabled-fieldset-disabled-legend-button">Button is tabbable/focusable</button></legend>
-    <input id="fieldset-enabled-fieldset-disabled-input" type="text" value="Input not tabbable/focusable" />
+    <a id="fieldset-enabled-anchor" href="#">Link is tabbable/focusable</a>
   </fieldset>
 
-  <a id="fieldset-enabled-anchor" href="#">Link is tabbable/focusable</a>
-</fieldset>
+  <fieldset id="fieldset-disabled" disabled>
+    <legend id="fieldset-disabled-legend1">
+      Disabled fieldset legend 1 (all ENABLED)
+      <button id="fieldset-disabled-legend1-button"
+        >Button is tabbable/focusable</button
+      >
+      <input
+        id="fieldset-disabled-legend1-input"
+        type="text"
+        value="Input is tabbable/focusable"
+      />
+      <select id="fieldset-disabled-legend1-select">
+        <option value="foo">Select is tabbable/focusable</option>
+      </select>
+      <textarea id="fieldset-disabled-legend1-textarea" cols="30" rows="10">
+Textarea is tabbable/focusable</textarea
+      >
+    </legend>
 
-<fieldset id="fieldset-disabled" disabled>
-  <legend id="fieldset-disabled-legend1">
-    Disabled fieldset legend 1 (all ENABLED)
-    <button id="fieldset-disabled-legend1-button">Button is tabbable/focusable</button>
-    <input id="fieldset-disabled-legend1-input" type="text" value="Input is tabbable/focusable">
-    <select id="fieldset-disabled-legend1-select">
-      <option value="foo">Select is tabbable/focusable</option>
-    </select>
-    <textarea id="fieldset-disabled-legend1-textarea" cols="30" rows="10">Textarea is tabbable/focusable</textarea>
-  </legend>
+    <legend id="fieldset-disabled-legend2">
+      Disabled fieldset legend 2 (all disabled)
+      <button id="fieldset-disabled-legend2-button"
+        >Button not tabbable/focusable</button
+      >
+      <input
+        id="fieldset-disabled-legend2-input"
+        type="text"
+        value="Input not tabbable/focusable"
+      />
+      <select id="fieldset-disabled-legend2-select">
+        <option value="foo">Select not tabbable/focusable</option>
+      </select>
+      <textarea id="fieldset-disabled-legend2-textarea" cols="30" rows="10">
+Textarea not tabbable/focusable</textarea
+      >
+    </legend>
 
-  <legend id="fieldset-disabled-legend2">
-    Disabled fieldset legend 2 (all disabled)
-    <button id="fieldset-disabled-legend2-button">Button not tabbable/focusable</button>
-    <input id="fieldset-disabled-legend2-input" type="text" value="Input not tabbable/focusable">
-    <select id="fieldset-disabled-legend2-select">
+    <button id="fieldset-disabled-button">Button not tabbable/focusable</button>
+    <input
+      id="fieldset-disabled-input"
+      type="text"
+      value="Input not tabbable/focusable"
+    />
+    <select id="fieldset-disabled-select">
       <option value="foo">Select not tabbable/focusable</option>
     </select>
-    <textarea id="fieldset-disabled-legend2-textarea" cols="30" rows="10">Textarea not tabbable/focusable</textarea>
-  </legend>
+    <textarea id="fieldset-disabled-textarea" cols="30" rows="10">
+Textarea not tabbable/focusable</textarea
+    >
 
-  <button id="fieldset-disabled-button">Button not tabbable/focusable</button>
-  <input id="fieldset-disabled-input" type="text" value="Input not tabbable/focusable">
-  <select id="fieldset-disabled-select">
-    <option value="foo">Select not tabbable/focusable</option>
-  </select>
-  <textarea id="fieldset-disabled-textarea" cols="30" rows="10">Textarea not tabbable/focusable</textarea>
+    <fieldset id="fieldset-disabled-fieldset-enabled">
+      <legend
+        ><button id="fieldset-disabled-fieldset-enabled-legend-button"
+          >Button not tabbable/focusable</button
+        ></legend
+      >
+      <input
+        id="fieldset-disabled-fieldset-enabled-input"
+        type="text"
+        value="Input not tabbable/focusable"
+      />
+    </fieldset>
 
-  <fieldset id="fieldset-disabled-fieldset-enabled">
-    <legend><button id="fieldset-disabled-fieldset-enabled-legend-button">Button not tabbable/focusable</button></legend>
-    <input id="fieldset-disabled-fieldset-enabled-input" type="text" value="Input not tabbable/focusable" />
+    <fieldset id="fieldset-disabled-fieldset-disabled" disabled>
+      <legend
+        ><button id="fieldset-disabled-fieldset-disabled-legend-button"
+          >Button not tabbable/focusable</button
+        ></legend
+      >
+      <input
+        id="fieldset-disabled-fieldset-disabled-input"
+        type="text"
+        value="Input not tabbable/focusable"
+      />
+    </fieldset>
+
+    <a id="fieldset-disabled-anchor" href="#">Link is tabbable/focusable</a>
   </fieldset>
-
-  <a id="fieldset-disabled-anchor" href="#">Link is tabbable/focusable</a>
-</fieldset>
 </div>


### PR DESCRIPTION
<!--
Thank you for your contribution! 🎉

Please be sure to go over the PR CHECKLIST below before posting your PR to make sure we all think of "everything". :)
-->

As noted in #596  `isDisabledFromFieldset` wasn't checking whether the disabled `<fieldset>` containing `node` is the top-most disabled `<fieldset>`. Now it does 🎉

Fixes #596

Note: I have no idea if there are tests for the case in which a form field is nested in the first `<legend>` of a disabled `<fieldset>` being nested in another disabled `<fieldset>`. If there are such tests, they need to be fixed too.

Edit: It looks like there are no such tests. There are no disabled `<fieldset>`s nested in another disabled `<fieldset>` in the structure of [fieldset.html](https://github.com/focus-trap/tabbable/blob/master/test/fixtures/fieldset.html). Should I add such a test?

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
