### PR TITLE
Optimizing `displayCheck: "full"`

### DIFF
--- a/.changeset/hip-tomatoes-hug.md
+++ b/.changeset/hip-tomatoes-hug.md
@@ -1,0 +1,5 @@
+---
+'tabbable': patch
+---
+
+Optimized and extended `displayCheck: "full"` option (now checks for any element having no display boxes) and added test for `display: "contents"` property (this bug was never reported). [(#592)](https://github.com/focus-trap/tabbable/issues/592)

--- a/src/index.js
+++ b/src/index.js
@@ -151,12 +151,7 @@ const isHidden = function (node, displayCheck) {
     return true;
   }
   if (!displayCheck || displayCheck === 'full') {
-    while (node) {
-      if (getComputedStyle(node).display === 'none') {
-        return true;
-      }
-      node = node.parentElement;
-    }
+    return !node.getClientRects().length;
   } else if (displayCheck === 'non-zero-area') {
     const { width, height } = node.getBoundingClientRect();
     return width === 0 && height === 0;

--- a/test/e2e/focusable.e2e.js
+++ b/test/e2e/focusable.e2e.js
@@ -330,6 +330,7 @@ describe('focusable', () => {
             'displayed-top',
             'displayed-nested',
             'displayed-zero-size',
+            'nested-under-displayed-contents',
           ];
           const container = document.createElement('div');
           container.innerHTML = fixtures.displayed;
@@ -348,7 +349,11 @@ describe('focusable', () => {
           );
         });
         it('return only elements with size ("non-zero-area" option)', () => {
-          const expectedFocusableIds = ['displayed-top', 'displayed-nested'];
+          const expectedFocusableIds = [
+            'displayed-top',
+            'displayed-nested',
+            'nested-under-displayed-contents',
+          ];
           const container = document.createElement('div');
           container.innerHTML = fixtures.displayed;
           document.body.append(container);
@@ -368,6 +373,8 @@ describe('focusable', () => {
             'displayed-none-top',
             'nested-under-displayed-none',
             'displayed-zero-size',
+            'displayed-contents-top',
+            'nested-under-displayed-contents',
           ];
           const container = document.createElement('div');
           container.innerHTML = fixtures.displayed;

--- a/test/e2e/isFocusable.e2e.js
+++ b/test/e2e/isFocusable.e2e.js
@@ -418,8 +418,11 @@ describe('isFocusable', () => {
         tabindex="0"
         style="display: none"
       >
-      <div data-testid="nested-under-displayed-none" tabindex="0"></div>
-    </div>
+        <div data-testid="nested-under-displayed-none" tabindex="0"></div>
+      </div>
+      <div data-testid="displayed-contents-top" tabindex="0" style="display: contents">
+        <div data-testid="nested-under-displayed-contents" tabindex="0"></div>
+      </div>
     `;
     function setupDisplayCheck() {
       const container = document.createElement('div');
@@ -434,6 +437,11 @@ describe('isFocusable', () => {
           container,
           'nested-under-displayed-none'
         ),
+        displayedContentsTop: getByTestId(container, 'displayed-contents-top'),
+        nestedUnderDisplayedContents: getByTestId(
+          container,
+          'nested-under-displayed-contents'
+        ),
       };
     }
 
@@ -444,6 +452,8 @@ describe('isFocusable', () => {
         displayedZeroSize,
         displayedNoneTop,
         nestedUnderDisplayedNone,
+        displayedContentsTop,
+        nestedUnderDisplayedContents,
       } = setupDisplayCheck();
 
       // default
@@ -452,14 +462,19 @@ describe('isFocusable', () => {
       expect(isFocusable(displayedZeroSize)).to.eql(true);
       expect(isFocusable(displayedNoneTop)).to.eql(false);
       expect(isFocusable(nestedUnderDisplayedNone)).to.eql(false);
+      expect(isFocusable(displayedContentsTop)).to.eql(false);
+      expect(isFocusable(nestedUnderDisplayedContents)).to.eql(true);
       // full
       const options = { displayCheck: 'full' };
       expect(isFocusable(displayedTop, options)).to.eql(true);
       expect(isFocusable(displayedNested, options)).to.eql(true);
       expect(isFocusable(displayedZeroSize, options)).to.eql(true);
-      expect(isFocusable(displayedNoneTop)).to.eql(false);
-      expect(isFocusable(nestedUnderDisplayedNone)).to.eql(false);
+      expect(isFocusable(displayedNoneTop, options)).to.eql(false);
+      expect(isFocusable(nestedUnderDisplayedNone, options)).to.eql(false);
+      expect(isFocusable(displayedContentsTop, options)).to.eql(false);
+      expect(isFocusable(nestedUnderDisplayedContents, options)).to.eql(true);
     });
+
     it('return only elements with size ("non-zero-area" option)', () => {
       const {
         displayedTop,
@@ -467,6 +482,8 @@ describe('isFocusable', () => {
         displayedZeroSize,
         displayedNoneTop,
         nestedUnderDisplayedNone,
+        displayedContentsTop,
+        nestedUnderDisplayedContents,
       } = setupDisplayCheck();
 
       const options = { displayCheck: 'non-zero-area' };
@@ -475,6 +492,8 @@ describe('isFocusable', () => {
       expect(isFocusable(displayedZeroSize, options)).to.eql(false);
       expect(isFocusable(displayedNoneTop, options)).to.eql(false);
       expect(isFocusable(nestedUnderDisplayedNone, options)).to.eql(false);
+      expect(isFocusable(displayedContentsTop, options)).to.eql(false);
+      expect(isFocusable(nestedUnderDisplayedContents, options)).to.eql(true);
     });
     it('return elements without checking display ("none" option)', () => {
       const {
@@ -483,6 +502,8 @@ describe('isFocusable', () => {
         displayedZeroSize,
         displayedNoneTop,
         nestedUnderDisplayedNone,
+        displayedContentsTop,
+        nestedUnderDisplayedContents,
       } = setupDisplayCheck();
 
       const options = { displayCheck: 'none' };
@@ -491,6 +512,8 @@ describe('isFocusable', () => {
       expect(isFocusable(displayedZeroSize, options)).to.eql(true);
       expect(isFocusable(displayedNoneTop, options)).to.eql(true);
       expect(isFocusable(nestedUnderDisplayedNone, options)).to.eql(true);
+      expect(isFocusable(displayedContentsTop, options)).to.eql(true);
+      expect(isFocusable(nestedUnderDisplayedContents, options)).to.eql(true);
     });
   });
 });

--- a/test/e2e/isTabbable.e2e.js
+++ b/test/e2e/isTabbable.e2e.js
@@ -406,7 +406,10 @@ describe('isTabbable', () => {
         style="display: none"
       >
       <div data-testid="nested-under-displayed-none" tabindex="0"></div>
-    </div>
+      </div>
+      <div data-testid="displayed-contents-top" tabindex="0" style="display: contents">
+        <div data-testid="nested-under-displayed-contents" tabindex="0"></div>
+      </div>
     `;
     function setupDisplayCheck() {
       const container = document.createElement('div');
@@ -421,6 +424,11 @@ describe('isTabbable', () => {
           container,
           'nested-under-displayed-none'
         ),
+        displayedContentsTop: getByTestId(container, 'displayed-contents-top'),
+        nestedUnderDisplayedContents: getByTestId(
+          container,
+          'nested-under-displayed-contents'
+        ),
       };
     }
     it('return browser visible elements by default ("full" option)', () => {
@@ -430,6 +438,8 @@ describe('isTabbable', () => {
         displayedZeroSize,
         displayedNoneTop,
         nestedUnderDisplayedNone,
+        displayedContentsTop,
+        nestedUnderDisplayedContents,
       } = setupDisplayCheck();
 
       // default
@@ -438,14 +448,18 @@ describe('isTabbable', () => {
       expect(isTabbable(displayedZeroSize)).to.eql(true);
       expect(isTabbable(displayedNoneTop)).to.eql(false);
       expect(isTabbable(nestedUnderDisplayedNone)).to.eql(false);
+      expect(isTabbable(displayedContentsTop)).to.eql(false);
+      expect(isTabbable(nestedUnderDisplayedContents)).to.eql(true);
       // full
       const options = { displayCheck: 'full' };
       expect(isTabbable(displayedTop, options)).to.eql(true);
       expect(isTabbable(displayedNested, options)).to.eql(true);
       expect(isTabbable(displayedZeroSize, options)).to.eql(true);
-      expect(isTabbable(displayedNoneTop)).to.eql(false);
-      expect(isTabbable(nestedUnderDisplayedNone)).to.eql(false);
+      expect(isTabbable(displayedNoneTop, options)).to.eql(false);
+      expect(isTabbable(nestedUnderDisplayedNone, options)).to.eql(false);
+      expect(isTabbable(nestedUnderDisplayedContents, options)).to.eql(true);
     });
+
     it('return only elements with size ("non-zero-area" option)', () => {
       const {
         displayedTop,
@@ -453,6 +467,8 @@ describe('isTabbable', () => {
         displayedZeroSize,
         displayedNoneTop,
         nestedUnderDisplayedNone,
+        displayedContentsTop,
+        nestedUnderDisplayedContents,
       } = setupDisplayCheck();
 
       const options = { displayCheck: 'non-zero-area' };
@@ -461,6 +477,8 @@ describe('isTabbable', () => {
       expect(isTabbable(displayedZeroSize, options)).to.eql(false);
       expect(isTabbable(displayedNoneTop, options)).to.eql(false);
       expect(isTabbable(nestedUnderDisplayedNone, options)).to.eql(false);
+      expect(isTabbable(displayedContentsTop, options)).to.eql(false);
+      expect(isTabbable(nestedUnderDisplayedContents, options)).to.eql(true);
     });
     it('return elements without checking display ("none" option)', () => {
       const {
@@ -469,6 +487,8 @@ describe('isTabbable', () => {
         displayedZeroSize,
         displayedNoneTop,
         nestedUnderDisplayedNone,
+        displayedContentsTop,
+        nestedUnderDisplayedContents,
       } = setupDisplayCheck();
 
       const options = { displayCheck: 'none' };
@@ -477,6 +497,8 @@ describe('isTabbable', () => {
       expect(isTabbable(displayedZeroSize, options)).to.eql(true);
       expect(isTabbable(displayedNoneTop, options)).to.eql(true);
       expect(isTabbable(nestedUnderDisplayedNone, options)).to.eql(true);
+      expect(isTabbable(displayedContentsTop, options)).to.eql(true);
+      expect(isTabbable(nestedUnderDisplayedContents, options)).to.eql(true);
     });
   });
 });

--- a/test/e2e/tabbable.e2e.js
+++ b/test/e2e/tabbable.e2e.js
@@ -359,6 +359,7 @@ describe('tabbable', () => {
             'displayed-top',
             'displayed-nested',
             'displayed-zero-size',
+            'nested-under-displayed-contents',
           ];
           const container = document.createElement('div');
           container.innerHTML = fixtures.displayed;
@@ -377,7 +378,11 @@ describe('tabbable', () => {
           );
         });
         it('return only elements with size ("non-zero-area" option)', () => {
-          const expectedTabbableIds = ['displayed-top', 'displayed-nested'];
+          const expectedTabbableIds = [
+            'displayed-top',
+            'displayed-nested',
+            'nested-under-displayed-contents',
+          ];
           const container = document.createElement('div');
           container.innerHTML = fixtures.displayed;
           document.body.append(container);
@@ -397,6 +402,8 @@ describe('tabbable', () => {
             'displayed-none-top',
             'nested-under-displayed-none',
             'displayed-zero-size',
+            'displayed-contents-top',
+            'nested-under-displayed-contents',
           ];
           const container = document.createElement('div');
           container.innerHTML = fixtures.displayed;

--- a/test/fixtures/displayed.html
+++ b/test/fixtures/displayed.html
@@ -5,3 +5,6 @@
   <div id="nested-under-displayed-none" tabindex="0"></div>
 </div>
 <div id="displayed-zero-size" tabindex="0" style="width: 0; height: 0"></div>
+<div id="displayed-contents-top" tabindex="0" style="display: contents">
+  <div id="nested-under-displayed-contents" tabindex="0"></div>
+</div>


### PR DESCRIPTION
<!--
Thank you for your contribution! 🎉

Please be sure to go over the PR CHECKLIST below before posting your PR to make sure we all think of "everything". :)
-->

Optimized `displayCheck: "full"` by replacing [this DOM traversal](https://github.com/focus-trap/tabbable/blob/7609e9ecf47941a2b69aab2149e8760ea1f7392e/src/index.js#L154) (executed on every potential focusable element) with the following statement:

```javascript
return !node.getClientRects().length;
```

which is a more general check for whether an elements has display boxes. `display: "none"` is only a special case of `!node.getClientRects().length`.

Another case of elements with no display boxes would be elements with `display: "contents"`. And (since this case wasn't previosly handled) tests have been added to cover this possibility.

Fixes #592


<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
