### PR TITLE
fix(index.js) The tabIndex of contentEditable elements was assumed to…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,10 +31,6 @@ const getCandidates = function (el, includeContainer, filter) {
   return candidates;
 };
 
-const isContentEditable = function (node) {
-  return node.contentEditable === 'true';
-};
-
 const getTabindex = function (node) {
   const tabindexAttr = parseInt(node.getAttribute('tabindex'), 10);
 
@@ -42,21 +38,15 @@ const getTabindex = function (node) {
     return tabindexAttr;
   }
 
-  // Browsers do not return `tabIndex` correctly for contentEditable nodes;
-  // so if they don't have a tabindex attribute specifically set, assume it's 0.
-  if (isContentEditable(node)) {
-    return 0;
-  }
-
   // in Chrome, <details/>, <audio controls/> and <video controls/> elements get a default
-  //  `tabIndex` of -1 when the 'tabindex' attribute isn't specified in the DOM,
-  //  yet they are still part of the regular tab order; in FF, they get a default
-  //  `tabIndex` of 0; since Chrome still puts those elements in the regular tab
-  //  order, consider their tab index to be 0.
+  // `tabIndex` of -1 when the 'tabindex' attribute isn't specified in the DOM,
+  // yet they are still part of the regular tab order; in FF, they get a default
+  // `tabIndex` of 0; since Chrome still puts those elements in the regular tab
+  // order, consider their tab index to be 0.
+  // Also browsers do not return `tabIndex` correctly for contentEditable nodes;
+  // so if they don't have a tabindex attribute specifically set, assume it's 0.
   if (
-    (node.nodeName === 'AUDIO' ||
-      node.nodeName === 'VIDEO' ||
-      node.nodeName === 'DETAILS') &&
+    (/^(AUDIO|VIDEO|DETAILS)$/.test(node.tagName) || node.isContentEditable) &&
     node.getAttribute('tabindex') === null
   ) {
     return 0;


### PR DESCRIPTION
… be zero in any case, not only in the case it was not specifically set.

<!--
Thank you for your contribution! 🎉

Please be sure to go over the PR CHECKLIST below before posting your PR to make sure we all think of "everything". :)
-->

Apart from fixing the little bug, I took the freedom to remove the `isContentEditable` function because it consists of a single statement and is being used only once. Also used a regex for checking `node.nodeName`.  
I can revert these changes if they are undesired.

Also I think that the logic of `getTabIndex` [can be simplified](https://github.com/DaviDevMod/tabbable/commit/d7a987be47270d980dde353f4a024d3fc6621a6e). Let me know if you want these changes in this current PR.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
