### PR TITLE
[#664] Assume node is visible when displayCheck=full if node not in document

### DIFF
--- a/.changeset/swift-jeans-roll.md
+++ b/.changeset/swift-jeans-roll.md
@@ -1,0 +1,5 @@
+---
+'tabbable': patch
+---
+
+Fixed an issue with `displayCheck=full` (default setting) determining all nodes were hidden when the container is not attached to the document. In this case, tabbable will revert to a `displayCheck=none` mode, which is the equivalent legacy behavior. Also updated the `displayCheck` option docs to add warnings about this corner case for the `full` and `non-zero-area` modes. `non-zero-area` behaves differently in the corner case. See the docs for more info.

--- a/src/index.js
+++ b/src/index.js
@@ -246,6 +246,11 @@ const isZeroArea = function (node) {
   return width === 0 && height === 0;
 };
 const isHidden = function (node, { displayCheck, getShadowRoot }) {
+  // NOTE: visibility will be `undefined` if node is detached from the document
+  //  (see notes about this further down), which means we will consider it visible
+  //  (this is legacy behavior from a very long way back)
+  // NOTE: we check this regardless of `displayCheck="none"` because this is a
+  //  _visibility_ check, not a _display_ check
   if (getComputedStyle(node).visibility === 'hidden') {
     return true;
   }
@@ -255,6 +260,28 @@ const isHidden = function (node, { displayCheck, getShadowRoot }) {
   if (matches.call(nodeUnderDetails, 'details:not([open]) *')) {
     return true;
   }
+
+  // The root node is the shadow root if the node is in a shadow DOM; some document otherwise
+  //  (but NOT _the_ document; see second 'If' comment below for more).
+  // If rootNode is shadow root, it'll have a host, which is the element to which the shadow
+  //  is attached, and the one we need to check if it's in the document or not (because the
+  //  shadow, and all nodes it contains, is never considered in the document since shadows
+  //  behave like self-contained DOMs; but if the shadow's HOST, which is part of the document,
+  //  is hidden, or is not in the document itself but is detached, it will affect the shadow's
+  //  visibility, including all the nodes it contains). The host could be any normal node,
+  //  or a custom element (i.e. web component). Either way, that's the one that is considered
+  //  part of the document, not the shadow root, nor any of its children (i.e. the node being
+  //  tested).
+  // If rootNode is not a shadow root, it won't have a host, and so rootNode should be the
+  //  document (per the docs) and while it's a Document-type object, that document does not
+  //  appear to be the same as the node's `ownerDocument` for some reason, so it's safer
+  //  to ignore the rootNode at this point, and use `node.ownerDocument`. Otherwise,
+  //  using `rootNode.contains(node)` will _always_ be true we'll get false-positives when
+  //  node is actually detached.
+  const nodeRootHost = getRootNode(node).host;
+  const nodeIsAttached =
+    nodeRootHost?.ownerDocument.contains(nodeRootHost) ||
+    node.ownerDocument.contains(node);
 
   if (!displayCheck || displayCheck === 'full') {
     if (typeof getShadowRoot === 'function') {
@@ -283,23 +310,50 @@ const isHidden = function (node, { displayCheck, getShadowRoot }) {
           node = parentElement;
         }
       }
+
       node = originalNode;
     }
     // else, `getShadowRoot` might be true, but all that does is enable shadow DOM support
     //  (i.e. it does not also presume that all nodes might have undisclosed shadows); or
     //  it might be a falsy value, which means shadow DOM support is disabled
 
-    // didn't find it sitting in an undisclosed shadow (or shadows are disabled) so now we
-    //  can just test to see if it would normally be visible or not
-    // this works wherever the node is: if there's at least one client rect, it's
-    //  somehow displayed; it also covers the CSS 'display: contents' case where the
-    //  node itself is hidden in place of its contents; and there's no need to search
-    //  up the hierarchy either
-    return !node.getClientRects().length;
+    // Since we didn't find it sitting in an undisclosed shadow (or shadows are disabled)
+    //  now we can just test to see if it would normally be visible or not, provided it's
+    //  attached to the main document.
+    // NOTE: We must consider case where node is inside a shadow DOM and given directly to
+    //  `isTabbable()` or `isFocusable()` -- regardless of `getShadowRoot` option setting.
+
+    if (nodeIsAttached) {
+      // this works wherever the node is: if there's at least one client rect, it's
+      //  somehow displayed; it also covers the CSS 'display: contents' case where the
+      //  node itself is hidden in place of its contents; and there's no need to search
+      //  up the hierarchy either
+      return !node.getClientRects().length;
+    }
+
+    // Else, the node isn't attached to the document, which means the `getClientRects()`
+    //  API will __always__ return zero rects (this can happen, for example, if React
+    //  is used to render nodes onto a detached tree, as confirmed in this thread:
+    //  https://github.com/facebook/react/issues/9117#issuecomment-284228870)
+    //
+    // It also means that even window.getComputedStyle(node).display will return `undefined`
+    //  because styles are only computed for nodes that are in the document.
+    //
+    // NOTE: THIS HAS BEEN THE CASE FOR YEARS. It is not new, nor is it caused by tabbable
+    //  somehow. Though it was never stated officially, anyone who has ever used tabbable
+    //  APIs on nodes in detached containers has actually implicitly used tabbable in what
+    //  was later (as of v5.2.0 on Apr 9, 2021) called `displayCheck="none"` mode -- essentially
+    //  considering __everything__ to be visible because of the innability to determine styles.
   } else if (displayCheck === 'non-zero-area') {
+    // NOTE: Even though this tests that the node's client rect is non-zero to determine
+    //  whether it's displayed, and that a detached node will __always__ have a zero-area
+    //  client rect, we don't special-case for whether the node is attached or not. In
+    //  this mode, we do want to consider nodes that have a zero area to be hidden at all
+    //  times, and that includes attached or not.
     return isZeroArea(node);
   }
 
+  // visible, as far as we can tell, or per current `displayCheck` mode
   return false;
 };
 

--- a/test/e2e/e2e.helpers.js
+++ b/test/e2e/e2e.helpers.js
@@ -26,7 +26,8 @@ export function removeAllChildNodes(parent) {
  * Renders a fixture into the body with support for shadow dom hydration
  * @param {string} content html content to be used as fixture
  * @param {SetupFixtureOptions} options
- * @returns {HTMLDivElement} return.container the element the fixture was rendered into
+ * @returns {{ container: HTMLDivElement }}
+ *  - container: the element the fixture was rendered into
  */
 export function setupFixture(content, options = {}) {
   const win = options.window || window;

--- a/test/e2e/focusable.e2e.js
+++ b/test/e2e/focusable.e2e.js
@@ -21,39 +21,80 @@ describe('focusable', () => {
   });
 
   describe('example fixtures', () => {
-    it('correctly identifies focusable elements in the "basic" example', () => {
-      const expectedFocusableIds = [
-        'contenteditable-true',
-        'contenteditable-nesting',
-        'contenteditable-negative-tabindex',
-        'contenteditable-NaN-tabindex',
-        'input',
-        'input-readonly',
-        'select',
-        'select-readonly',
-        'href-anchor',
-        'tabindex-hrefless-anchor',
-        'textarea',
-        'textarea-readonly',
-        'button',
-        'tabindex-div',
-        'negative-select',
-        'hiddenParentVisible-button',
-        'audio-control',
-        'audio-control-NaN-tabindex',
-        'video-control',
-        'video-control-NaN-tabindex',
-      ];
+    [true, false].forEach((inDocument) => {
+      it(`correctly identifies focusable elements in the "basic" example ${
+        inDocument ? '(container IN doc)' : '(container NOT in doc)'
+      }`, () => {
+        let expectedFocusableIds;
 
-      const container = document.createElement('div');
-      container.innerHTML = fixtures.basic;
-      document.body.append(container);
+        if (inDocument) {
+          expectedFocusableIds = [
+            'contenteditable-true',
+            'contenteditable-nesting',
+            'contenteditable-negative-tabindex',
+            'contenteditable-NaN-tabindex',
+            'input',
+            'input-readonly',
+            'select',
+            'select-readonly',
+            'href-anchor',
+            'tabindex-hrefless-anchor',
+            'textarea',
+            'textarea-readonly',
+            'button',
+            'tabindex-div',
+            'negative-select',
+            'hiddenParentVisible-button',
+            'displaycontents-child',
+            'audio-control',
+            'audio-control-NaN-tabindex',
+            'video-control',
+            'video-control-NaN-tabindex',
+          ];
+        } else {
+          expectedFocusableIds = [
+            'contenteditable-true',
+            'contenteditable-nesting',
+            'contenteditable-negative-tabindex',
+            'contenteditable-NaN-tabindex',
+            'input',
+            'input-readonly',
+            'select',
+            'select-readonly',
+            'href-anchor',
+            'tabindex-hrefless-anchor',
+            'textarea',
+            'textarea-readonly',
+            'button',
+            'tabindex-div',
+            'negative-select',
+            'displaynone-textarea',
+            'visibilityhidden-button',
+            'hiddenParent-button',
+            'hiddenParentVisible-button',
+            'displaycontents',
+            'displaycontents-child',
+            'displaycontents-child-displaynone',
+            'audio-control',
+            'audio-control-NaN-tabindex',
+            'video-control',
+            'video-control-NaN-tabindex',
+          ];
+        }
 
-      const focusableElements = focusable(container);
+        const container = document.createElement('div');
+        container.innerHTML = fixtures.basic;
 
-      expect(getIdsFromElementsArray(focusableElements)).to.eql(
-        expectedFocusableIds
-      );
+        if (inDocument) {
+          document.body.append(container);
+        }
+
+        const focusableElements = focusable(container);
+
+        expect(getIdsFromElementsArray(focusableElements)).to.eql(
+          expectedFocusableIds
+        );
+      });
     });
 
     it('correctly identifies focusable elements in the "nested" example', () => {

--- a/test/e2e/isFocusable.e2e.js
+++ b/test/e2e/isFocusable.e2e.js
@@ -439,10 +439,15 @@ describe('isFocusable', () => {
         <div data-testid="nested-under-displayed-contents" tabindex="0"></div>
       </div>
     `;
-    function setupDisplayCheck() {
+
+    function setupDisplayCheck(inDocument = true) {
       const container = document.createElement('div');
       container.innerHTML = fixture;
-      document.body.append(container);
+
+      if (inDocument) {
+        document.body.append(container);
+      }
+
       return {
         displayedTop: getByTestId(container, 'displayed-top'),
         displayedNested: getByTestId(container, 'displayed-nested'),
@@ -510,25 +515,30 @@ describe('isFocusable', () => {
       expect(isFocusable(displayedContentsTop, options)).to.eql(false);
       expect(isFocusable(nestedUnderDisplayedContents, options)).to.eql(true);
     });
-    it('return elements without checking display ("none" option)', () => {
-      const {
-        displayedTop,
-        displayedNested,
-        displayedZeroSize,
-        displayedNoneTop,
-        nestedUnderDisplayedNone,
-        displayedContentsTop,
-        nestedUnderDisplayedContents,
-      } = setupDisplayCheck();
 
-      const options = { displayCheck: 'none' };
-      expect(isFocusable(displayedTop, options)).to.eql(true);
-      expect(isFocusable(displayedNested, options)).to.eql(true);
-      expect(isFocusable(displayedZeroSize, options)).to.eql(true);
-      expect(isFocusable(displayedNoneTop, options)).to.eql(true);
-      expect(isFocusable(nestedUnderDisplayedNone, options)).to.eql(true);
-      expect(isFocusable(displayedContentsTop, options)).to.eql(true);
-      expect(isFocusable(nestedUnderDisplayedContents, options)).to.eql(true);
+    [true, false].forEach((inDocument) => {
+      it(`return elements without checking display ("${
+        inDocument ? 'none' : 'full'
+      }" option, container ${inDocument ? 'IN doc' : 'NOT in doc'})`, () => {
+        const {
+          displayedTop,
+          displayedNested,
+          displayedZeroSize,
+          displayedNoneTop,
+          nestedUnderDisplayedNone,
+          displayedContentsTop,
+          nestedUnderDisplayedContents,
+        } = setupDisplayCheck(inDocument);
+
+        const options = { displayCheck: 'none' };
+        expect(isFocusable(displayedTop, options)).to.eql(true);
+        expect(isFocusable(displayedNested, options)).to.eql(true);
+        expect(isFocusable(displayedZeroSize, options)).to.eql(true);
+        expect(isFocusable(displayedNoneTop, options)).to.eql(true);
+        expect(isFocusable(nestedUnderDisplayedNone, options)).to.eql(true);
+        expect(isFocusable(displayedContentsTop, options)).to.eql(true);
+        expect(isFocusable(nestedUnderDisplayedContents, options)).to.eql(true);
+      });
     });
   });
 });

--- a/test/e2e/isTabbable.e2e.js
+++ b/test/e2e/isTabbable.e2e.js
@@ -426,10 +426,14 @@ describe('isTabbable', () => {
         <div data-testid="nested-under-displayed-contents" tabindex="0"></div>
       </div>
     `;
-    function setupDisplayCheck() {
+
+    function setupDisplayCheck(inDocument = true) {
       const container = document.createElement('div');
       container.innerHTML = fixture;
-      document.body.append(container);
+      if (inDocument) {
+        document.body.append(container);
+      }
+
       return {
         displayedTop: getByTestId(container, 'displayed-top'),
         displayedNested: getByTestId(container, 'displayed-nested'),
@@ -446,6 +450,7 @@ describe('isTabbable', () => {
         ),
       };
     }
+
     it('return browser visible elements by default ("full" option)', () => {
       const {
         displayedTop,
@@ -495,25 +500,31 @@ describe('isTabbable', () => {
       expect(isTabbable(displayedContentsTop, options)).to.eql(false);
       expect(isTabbable(nestedUnderDisplayedContents, options)).to.eql(true);
     });
-    it('return elements without checking display ("none" option)', () => {
-      const {
-        displayedTop,
-        displayedNested,
-        displayedZeroSize,
-        displayedNoneTop,
-        nestedUnderDisplayedNone,
-        displayedContentsTop,
-        nestedUnderDisplayedContents,
-      } = setupDisplayCheck();
 
-      const options = { displayCheck: 'none' };
-      expect(isTabbable(displayedTop, options)).to.eql(true);
-      expect(isTabbable(displayedNested, options)).to.eql(true);
-      expect(isTabbable(displayedZeroSize, options)).to.eql(true);
-      expect(isTabbable(displayedNoneTop, options)).to.eql(true);
-      expect(isTabbable(nestedUnderDisplayedNone, options)).to.eql(true);
-      expect(isTabbable(displayedContentsTop, options)).to.eql(true);
-      expect(isTabbable(nestedUnderDisplayedContents, options)).to.eql(true);
+    [true, false].forEach((inDocument) => {
+      it(`return elements without checking display ("${
+        inDocument ? 'none' : 'full'
+      }" option, container ${inDocument ? 'IN doc' : 'NOT in doc'})`, () => {
+        const {
+          displayedTop,
+          displayedNested,
+          displayedZeroSize,
+          displayedNoneTop,
+          nestedUnderDisplayedNone,
+          displayedContentsTop,
+          nestedUnderDisplayedContents,
+        } = setupDisplayCheck(inDocument);
+
+        // when container is NOT in the document, 'full' behaves like 'none'
+        const options = { displayCheck: inDocument ? 'none' : 'full' };
+        expect(isTabbable(displayedTop, options)).to.eql(true);
+        expect(isTabbable(displayedNested, options)).to.eql(true);
+        expect(isTabbable(displayedZeroSize, options)).to.eql(true);
+        expect(isTabbable(displayedNoneTop, options)).to.eql(true);
+        expect(isTabbable(nestedUnderDisplayedNone, options)).to.eql(true);
+        expect(isTabbable(displayedContentsTop, options)).to.eql(true);
+        expect(isTabbable(nestedUnderDisplayedContents, options)).to.eql(true);
+      });
     });
   });
 });

--- a/test/e2e/shadow-dom.e2e.js
+++ b/test/e2e/shadow-dom.e2e.js
@@ -37,18 +37,45 @@ describe('web-components', () => {
       const lightRadio3 = container.querySelector('#light-radio3');
 
       // always focusable
-      expect(isFocusable(shadowRadio1), 'checked in shadow').to.eql(true);
-      expect(isFocusable(shadowRadio2), 'not checked in shadow').to.eql(true);
-      expect(isFocusable(lightRadio1), 'checked in light').to.eql(true);
-      expect(isFocusable(radio2Slotted), 'not checked slotted').to.eql(true);
-      expect(isFocusable(lightRadio3), 'not checked in light').to.eql(true);
+      expect(isFocusable(shadowRadio1), '(focusable) checked in shadow').to.eql(
+        true
+      );
+      expect(
+        isFocusable(shadowRadio2),
+        '(focusable) not checked in shadow'
+      ).to.eql(true);
+      expect(isFocusable(lightRadio1), '(focusable) checked in light').to.eql(
+        true
+      );
+      expect(
+        isFocusable(radio2Slotted),
+        '(focusable) not checked slotted'
+      ).to.eql(true);
+      expect(
+        isFocusable(lightRadio3),
+        '(focusable) not checked in light'
+      ).to.eql(true);
+
       // only the first checked is tabbable
-      expect(isTabbable(shadowRadio1), 'checked in shadow').to.eql(true);
-      expect(isTabbable(shadowRadio2), 'not checked in shadow').to.eql(false);
-      expect(isTabbable(lightRadio1), 'checked in light').to.eql(true);
-      expect(isTabbable(radio2Slotted), 'not checked slotted').to.eql(false);
-      expect(isTabbable(lightRadio3), 'not checked in light').to.eql(false);
+      expect(isTabbable(shadowRadio1), '(tabbable) checked in shadow').to.eql(
+        true
+      );
+      expect(
+        isTabbable(shadowRadio2),
+        '(tabbable) not checked in shadow'
+      ).to.eql(false);
+      expect(isTabbable(lightRadio1), '(tabbable) checked in light').to.eql(
+        true
+      );
+      expect(
+        isTabbable(radio2Slotted),
+        '(tabbable) not checked slotted'
+      ).to.eql(false);
+      expect(isTabbable(lightRadio3), '(tabbable) not checked in light').to.eql(
+        false
+      );
     });
+
     it('should not match elements in shadow root with a "display=none" ancestor', () => {
       const { container } = setupFixture(fixtures.shadowDomDisplay, {
         window,
@@ -59,16 +86,24 @@ describe('web-components', () => {
       const lightInputSlotted = container.querySelector('#light-input-slotted');
 
       // focusable
-      expect(isFocusable(shadowInput), 'non display shadow').to.eql(false);
-      expect(isFocusable(lightInputSlotted), 'non display slotted').to.eql(
+      expect(isFocusable(shadowInput), '(focusable) non display shadow').to.eql(
         false
       );
+      expect(
+        isFocusable(lightInputSlotted),
+        '(focusable) non display slotted'
+      ).to.eql(false);
+
       // tabbable
-      expect(isTabbable(shadowInput), 'non display shadow').to.eql(false);
-      expect(isTabbable(lightInputSlotted), 'non display slotted').to.eql(
+      expect(isTabbable(shadowInput), '(tabbable) non display shadow').to.eql(
         false
       );
+      expect(
+        isTabbable(lightInputSlotted),
+        '(tabbable) non display slotted'
+      ).to.eql(false);
     });
+
     it('should not match elements in a non display slot', () => {
       const { container } = setupFixture(fixtures.shadowDomDisplay, {
         window,
@@ -79,6 +114,7 @@ describe('web-components', () => {
       expect(isFocusable(lightInputSlotted)).to.eql(false);
       expect(isTabbable(lightInputSlotted)).to.eql(false);
     });
+
     it('should not match elements in a closed shadow root with inner display="none" (fallback to zero-area-size)', () => {
       const { container } = setupFixture(fixtures.shadowDomDisplay, {
         window,
@@ -100,6 +136,7 @@ describe('web-components', () => {
         }),
         'fallback to zero size check for unreached shadow root but still not focusable'
       ).to.eql(false);
+
       // tabbable
       expect(
         isTabbable(lightDisplayNoneSlotted),
@@ -112,6 +149,7 @@ describe('web-components', () => {
         'fallback to zero size for unreached shadow root but still not tabbable'
       ).to.eql(false);
     });
+
     it('should not match slot elements', () => {
       const { container } = setupFixture(fixtures.shadowDomQuery, {
         window,
@@ -126,6 +164,7 @@ describe('web-components', () => {
       expect(isTabbable(slotWithTabIndex), 'slot not tabbable').to.eql(false);
     });
   });
+
   describe('query', () => {
     it('should find elements inside shadow dom', () => {
       const expected = ['light-before', 'shadow-input', 'light-after'];

--- a/test/e2e/tabbable.e2e.js
+++ b/test/e2e/tabbable.e2e.js
@@ -21,37 +21,78 @@ describe('tabbable', () => {
   });
 
   describe('example fixtures', () => {
-    it('correctly identifies tabbable elements in the "basic" example', () => {
-      const expectedTabbableIds = [
-        'tabindex-hrefless-anchor',
-        'contenteditable-true',
-        'contenteditable-nesting',
-        'contenteditable-NaN-tabindex',
-        'input',
-        'input-readonly',
-        'select',
-        'select-readonly',
-        'href-anchor',
-        'textarea',
-        'textarea-readonly',
-        'button',
-        'tabindex-div',
-        'hiddenParentVisible-button',
-        'audio-control',
-        'audio-control-NaN-tabindex',
-        'video-control',
-        'video-control-NaN-tabindex',
-      ];
+    [true, false].forEach((inDocument) => {
+      it(`correctly identifies tabbable elements in the "basic" example ${
+        inDocument ? '(container IN doc)' : '(container NOT in doc)'
+      }`, () => {
+        let expectedTabbableIds;
 
-      const container = document.createElement('div');
-      container.innerHTML = fixtures.basic;
-      document.body.append(container);
+        if (inDocument) {
+          expectedTabbableIds = [
+            'tabindex-hrefless-anchor',
+            'contenteditable-true',
+            'contenteditable-nesting',
+            'contenteditable-NaN-tabindex',
+            'input',
+            'input-readonly',
+            'select',
+            'select-readonly',
+            'href-anchor',
+            'textarea',
+            'textarea-readonly',
+            'button',
+            'tabindex-div',
+            'hiddenParentVisible-button',
+            'displaycontents-child',
+            'audio-control',
+            'audio-control-NaN-tabindex',
+            'video-control',
+            'video-control-NaN-tabindex',
+          ];
+        } else {
+          // any node that has 'visibility: hidden' or 'display: hidden|contents'
+          //  will be considered visible and so tabbable
+          expectedTabbableIds = [
+            'tabindex-hrefless-anchor',
+            'contenteditable-true',
+            'contenteditable-nesting',
+            'contenteditable-NaN-tabindex',
+            'input',
+            'input-readonly',
+            'select',
+            'select-readonly',
+            'href-anchor',
+            'textarea',
+            'textarea-readonly',
+            'button',
+            'tabindex-div',
+            'displaynone-textarea',
+            'visibilityhidden-button',
+            'hiddenParent-button',
+            'hiddenParentVisible-button',
+            'displaycontents',
+            'displaycontents-child',
+            'displaycontents-child-displaynone',
+            'audio-control',
+            'audio-control-NaN-tabindex',
+            'video-control',
+            'video-control-NaN-tabindex',
+          ];
+        }
 
-      const tabbableElements = tabbable(container);
+        const container = document.createElement('div');
+        container.innerHTML = fixtures.basic;
 
-      expect(getIdsFromElementsArray(tabbableElements)).to.eql(
-        expectedTabbableIds
-      );
+        if (inDocument) {
+          document.body.append(container);
+        }
+
+        const tabbableElements = tabbable(container);
+
+        expect(getIdsFromElementsArray(tabbableElements)).to.eql(
+          expectedTabbableIds
+        );
+      });
     });
 
     it('correctly identifies tabbable elements in the "nested" example', () => {

--- a/test/fixtures/basic.html
+++ b/test/fixtures/basic.html
@@ -54,6 +54,11 @@
 </div>
 <div id="noindex-div">foo</div>
 
+<div id="displaycontents" style="display: contents; background-color: lime;" tabindex="0">
+  <div id="displaycontents-child" tabindex="0">displaycontents-child</div>
+  <div id="displaycontents-child-displaynone" style="display: none" tabindex="0">displaycontents-child-displaynone</div>
+</div>
+
 <audio id="audio-control" controls></audio>
 <audio id="audio-nocontrol"></audio>
 <audio id="audio-control-NaN-tabindex" tabindex="foo" controls></audio>


### PR DESCRIPTION
Fixes #664

There are legitimate cases where tabbable's APIs are expected to work on container
nodes that are not actually attached to the document. The result is that the
`getClientRects()` API never returns any rects for visible nodes, resulting in
tabbable thinking ALL nodes in the container are hidden.

__NOTE:__ Assuming the node is visible under the default/legacy "full" mode
when the node is __not__ in the document is actually the legacy behavior.
When a node is detached, `getComputedStyle(node).display` is always
`undefined` and our checks were explicitly verifying if
`getComputedStyle(node).display === 'none'` to conclude a node was
hidden, which means this check would fail and we could conclude the
node was __visible__ even if it was not.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
