### PR TITLE
fix: tabbable sometimes incorrectly includes children of a web component

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -140,6 +140,15 @@
       "contributions": [
         "bug"
       ]
+    },
+    {
+      "login": "BFrost",
+      "name": "bfrost",
+      "avatar_url": "https://avatars.githubusercontent.com/u/3368761?v=4",
+      "profile": "https://github.com/BFrost",
+      "contributions": [
+        "bug"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.changeset/violet-mugs-whisper.md
+++ b/.changeset/violet-mugs-whisper.md
@@ -1,0 +1,5 @@
+---
+'tabbable': patch
+---
+
+fix: align with browser behaviour when a web component has a negative tabindex

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tabbable [![CI](https://github.com/focus-trap/tabbable/workflows/CI/badge.svg?branch=master&event=push)](https://github.com/focus-trap/tabbable/actions?query=workflow:CI+branch:master) [![Codecov](https://img.shields.io/codecov/c/github/focus-trap/tabbable)](https://codecov.io/gh/focus-trap/tabbable) [![license](https://badgen.now.sh/badge/license/MIT)](./LICENSE)
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-12-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-13-orange.svg?style=flat-square)](#contributors)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Small utility that returns an array of all\* tabbable DOM nodes within a containing node.
@@ -238,6 +238,7 @@ In alphabetical order:
     <td align="center"><a href="https://github.com/rvsia"><img src="https://avatars.githubusercontent.com/u/32869456?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Richard Všianský</b></sub></a><br /><a href="https://github.com/focus-trap/tabbable/commits?author=rvsia" title="Documentation">📖</a></td>
     <td align="center"><a href="https://stefancameron.com/"><img src="https://avatars3.githubusercontent.com/u/2855350?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Stefan Cameron</b></sub></a><br /><a href="https://github.com/focus-trap/tabbable/commits?author=stefcameron" title="Code">💻</a> <a href="https://github.com/focus-trap/tabbable/issues?q=author%3Astefcameron" title="Bug reports">🐛</a> <a href="#infra-stefcameron" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="https://github.com/focus-trap/tabbable/commits?author=stefcameron" title="Tests">⚠️</a> <a href="https://github.com/focus-trap/tabbable/commits?author=stefcameron" title="Documentation">📖</a> <a href="#maintenance-stefcameron" title="Maintenance">🚧</a></td>
     <td align="center"><a href="http://tylerhawkins.info/201R/"><img src="https://avatars0.githubusercontent.com/u/13806458?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tyler Hawkins</b></sub></a><br /><a href="#tool-thawkin3" title="Tools">🔧</a> <a href="https://github.com/focus-trap/tabbable/commits?author=thawkin3" title="Tests">⚠️</a> <a href="#infra-thawkin3" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="https://github.com/focus-trap/tabbable/commits?author=thawkin3" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/BFrost"><img src="https://avatars.githubusercontent.com/u/3368761?v=4?s=100" width="100px;" alt=""/><br /><sub><b>bfrost</b></sub></a><br /><a href="https://github.com/focus-trap/tabbable/issues?q=author%3ABFrost" title="Bug reports">🐛</a></td>
     <td align="center"><a href="https://github.com/pebble2050"><img src="https://avatars1.githubusercontent.com/u/47210889?v=4?s=100" width="100px;" alt=""/><br /><sub><b>pebble2050</b></sub></a><br /><a href="https://github.com/focus-trap/tabbable/issues?q=author%3Apebble2050" title="Bug reports">🐛</a></td>
   </tr>
 </table>

--- a/test/e2e/shadow-dom.e2e.js
+++ b/test/e2e/shadow-dom.e2e.js
@@ -245,6 +245,22 @@ describe('web-components', () => {
       expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
     });
 
+    it('should not find elements inside shadow dom that browsers will skip due to -1 tabindex on host', () => {
+      const expected = [];
+      const { container } = setupFixture(fixtures['shadow-dom-untabbable'], {
+        window,
+      });
+      const shadowElement = container.querySelector('test-shadow');
+
+      let result = tabbable(shadowElement, { getShadowRoot() {} });
+      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+        expected
+      );
+
+      result = tabbable(shadowElement, { getShadowRoot: true });
+      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
+    });
+
     it('should sort slots inside shadow dom', () => {
       const expected = [
         'light-before',

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -36,4 +36,8 @@ module.exports = {
     path.join(__dirname, 'shadow-dom-query.html'),
     'utf8'
   ),
+  'shadow-dom-untabbable': fs.readFileSync(
+    path.join(__dirname, 'shadow-dom-untabbable.html'),
+    'utf8'
+  ),
 };

--- a/test/fixtures/shadow-dom-untabbable.html
+++ b/test/fixtures/shadow-dom-untabbable.html
@@ -1,0 +1,7 @@
+<test-shadow tabindex="-1">
+  <template shadowroot="open">
+    <div id="container">
+      <input id="input" type="text" />
+    </div>
+  </template>
+</test-shadow>


### PR DESCRIPTION
<!--
Thank you for your contribution! 🎉

Please be sure to go over the PR CHECKLIST below before posting your PR to make sure we all think of "everything". :)
-->

## Use Case
A browser will skip tab-targeting an element if it is the only child of a web component which has a tabindex of -1.

## Example

```html
<my-input tabindex="-1">
  <input id="input" type="text" />
</my-nput>
```

## Expected behaviour
`tabbable()` should return an empty list for the example above

## Actual behaviour
`tabbable()` returns a list which includes the input depicted above

## Impact
This bug can cause a focus-trap to behave erratically when nearing the end of focusable elements.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
