### PR TITLE
[832] Fix bug with tabbable scoped table headers

### DIFF
--- a/.changeset/calm-toys-learn.md
+++ b/.changeset/calm-toys-learn.md
@@ -1,0 +1,5 @@
+---
+'tabbable': patch
+---
+
+Fix crash with tabbable scoped table header elements ([#832](https://github.com/focus-trap/tabbable/issues/832))

--- a/src/index.js
+++ b/src/index.js
@@ -56,9 +56,9 @@ const getCandidates = function (el, includeContainer, filter) {
  */
 
 /**
- * @typedef {Object} CandidatesScope
- * @property {Element} scope contains inner candidates
- * @property {Element[]} candidates
+ * @typedef {Object} CandidateScope
+ * @property {Element} scopeParent contains inner candidates
+ * @property {Element[]} candidates list of candidates found in the scope parent
  */
 
 /**
@@ -67,7 +67,7 @@ const getCandidates = function (el, includeContainer, filter) {
  *  if a function, implies shadow support is enabled and either returns the shadow root of an element
  *  or a boolean stating if it has an undisclosed shadow root
  * @property {(node: Element) => boolean} filter filter candidates
- * @property {boolean} flatten if true then result will flatten any CandidatesScope into the returned list
+ * @property {boolean} flatten if true then result will flatten any CandidateScope into the returned list
  * @property {ShadowRootFilter} shadowRootFilter filter shadow roots;
  */
 
@@ -75,7 +75,7 @@ const getCandidates = function (el, includeContainer, filter) {
  * @param {Element[]} elements list of element containers to match candidates from
  * @param {boolean} includeContainer add container list to check
  * @param {IterativeOptions} options
- * @returns {Array.<Element|CandidatesScope>}
+ * @returns {Array.<Element|CandidateScope>}
  */
 const getCandidatesIteratively = function (
   elements,
@@ -95,7 +95,7 @@ const getCandidatesIteratively = function (
         candidates.push(...nestedCandidates);
       } else {
         candidates.push({
-          scope: element,
+          scopeParent: element,
           candidates: nestedCandidates,
         });
       }
@@ -137,7 +137,7 @@ const getCandidatesIteratively = function (
           candidates.push(...nestedCandidates);
         } else {
           candidates.push({
-            scope: element,
+            scopeParent: element,
             candidates: nestedCandidates,
           });
         }
@@ -464,15 +464,15 @@ const isValidShadowRootTabbable = function (shadowHostNode) {
 };
 
 /**
- * @param {Array.<Element|CandidatesScope>} candidates
+ * @param {Array.<Element|CandidateScope>} candidates
  * @returns Element[]
  */
 const sortByOrder = function (candidates) {
   const regularTabbables = [];
   const orderedTabbables = [];
   candidates.forEach(function (item, i) {
-    const isScope = !!item.scope;
-    const element = isScope ? item.scope : item;
+    const isScope = !!item.scopeParent;
+    const element = isScope ? item.scopeParent : item;
     const candidateTabindex = getTabindex(element, isScope);
     const elements = isScope ? sortByOrder(item.candidates) : element;
     if (candidateTabindex === 0) {

--- a/test/e2e/shadow-dom.cy.js
+++ b/test/e2e/shadow-dom.cy.js
@@ -165,7 +165,7 @@ describe('web-components', () => {
     });
   });
 
-  describe('query', () => {
+  describe('tabbable/focusable', () => {
     it('should find elements inside shadow dom', () => {
       const expected = ['light-before', 'shadow-input', 'light-after'];
       const { container } = setupFixture(fixtures.shadowDomQuery, {
@@ -201,6 +201,25 @@ describe('web-components', () => {
 
       result = tabbable(container, { getShadowRoot: true });
       expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
+    });
+
+    // make sure we're not conflicting with valid `scope` attribute on <th> elements
+    //  when we're sorting nodes in tab order (we don't test focusable() because
+    //  there's no focus order)
+    it('should find tabbable scoped headers', () => {
+      const expected = [
+        'header-athlete-col',
+        'header-swim-col',
+        'header-bike-col',
+        'header-run-col',
+      ];
+      const { container } = setupFixture(fixtures.shadowDomQuery, {
+        window,
+        caseId: 'table-with-tabbable-scoped-headers',
+      });
+
+      const result = tabbable(container);
+      expect(getIdsFromElementsArray(result), 'tabbable').to.eql(expected);
     });
 
     it('should find elements inside shadow dom when directly querying the element with shadow root', () => {

--- a/test/fixtures/shadow-dom-query.html
+++ b/test/fixtures/shadow-dom-query.html
@@ -162,3 +162,33 @@
         <input id="query-light-input-slotted"></input>
     </test-shadow>
 </div>
+
+<div id="table-with-tabbable-scoped-headers">
+    <h2>table with tabbable scoped headers</h2>
+    <table>
+        <tr>
+            <th scope="col" tabindex="0" id="header-athlete-col">Athlete</th>
+            <th scope="col" tabindex="0" id="header-swim-col">Swim</th>
+            <th scope="col" tabindex="0" id="header-bike-col">Bike</th>
+            <th scope="col" tabindex="0" id="header-run-col">Run</th>
+        </tr>
+        <tr>
+            <th scope="row" id="header-athlete-row">John</th>
+            <td>7</td>
+            <td>12</td>
+            <td>10</td>
+        </tr>
+        <tr>
+            <th scope="row">Lisa</th>
+            <td>3</td>
+            <td>15</td>
+            <td>9</td>
+        </tr>
+        <tr>
+            <th scope="row">Paul</th>
+            <td>9</td>
+            <td>8</td>
+            <td>12</td>
+        </tr>
+    </table>
+</div>


### PR DESCRIPTION
Fixes #832

For shadow DOM support, we create internal objects with a `scope` property when looking for tabbable/focusable candidates. But when we sort the tabbable candidates, we look for an existing `scope` property assuming that HTMLElements don't have one, but it turns out `<th>` elements do have a `scope` attribute (and so `scope` property) and we mistake it for being a shadow DOM scope parent element. Crashing ensues.

So this just renames `CandidateScope.scope` to `CandidateScope.scopeParent` and adds a test to make sure things work as expected.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
