### PR TITLE
[ftr#905] Fix crash when ownerDocument is null

### DIFF
--- a/.changeset/eight-bulldogs-shake.md
+++ b/.changeset/eight-bulldogs-shake.md
@@ -2,4 +2,4 @@
 'tabbable': patch
 ---
 
-Fix a corner case (crash) where the `ownerDocument` could be `null` while checking if a node is attached ([#905](https://github.com/focus-trap/focus-trap-react/issues/905))
+Fix a corner case (crash) where the `ownerDocument` could be `null` while checking if a node is attached ([focus-trap-react #905](https://github.com/focus-trap/focus-trap-react/issues/905))

--- a/.changeset/eight-bulldogs-shake.md
+++ b/.changeset/eight-bulldogs-shake.md
@@ -1,0 +1,5 @@
+---
+'tabbable': patch
+---
+
+Fix a corner case (crash) where the `ownerDocument` could be `null` while checking if a node is attached ([#905](https://github.com/focus-trap/focus-trap-react/issues/905))

--- a/.changeset/eight-bulldogs-shake.md
+++ b/.changeset/eight-bulldogs-shake.md
@@ -2,4 +2,4 @@
 'tabbable': patch
 ---
 
-Fix a corner case (crash) where the `ownerDocument` could be `null` while checking if a node is attached ([focus-trap-react #905](https://github.com/focus-trap/focus-trap-react/issues/905))
+Fix a corner case where a node's root node can be itself, indicating detachment from the DOM, leading to a crash in `isHidden() -> isNodeAttached() -> getRootNode()` if not handled properly ([focus-trap-react #905](https://github.com/focus-trap/focus-trap-react/issues/905))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabbable",
-  "version": "6.0.2-tabbable-i905.1",
+  "version": "6.0.2-tabbable-i905.2",
   "description": "Returns an array of all tabbable DOM nodes within a containing node.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabbable",
-  "version": "6.0.2-tabbable-i905.2",
+  "version": "6.0.1",
   "description": "Returns an array of all tabbable DOM nodes within a containing node.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabbable",
-  "version": "6.0.1",
+  "version": "6.0.2-tabbable-i905.0",
   "description": "Returns an array of all tabbable DOM nodes within a containing node.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tabbable",
-  "version": "6.0.2-tabbable-i905.0",
+  "version": "6.0.2-tabbable-i905.1",
   "description": "Returns an array of all tabbable DOM nodes within a containing node.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,8 @@ const matches = NoElement
 
 const getRootNode =
   !NoElement && Element.prototype.getRootNode
-    ? (element) => element.getRootNode()
-    : (element) => element.ownerDocument;
+    ? (element) => element?.getRootNode?.()
+    : (element) => element?.ownerDocument;
 
 /**
  * @param {Element} el container to check in
@@ -276,18 +276,26 @@ const isNodeAttached = function (node) {
   //  if a tabbable/focusable node was quickly added to the DOM, focused, and then removed
   //  from the DOM as in https://github.com/focus-trap/focus-trap-react/issues/905), then
   //  `ownerDocument` will be `null`, hence the optional chaining on it.
-  let nodeRootHost = node && getRootNode(node).host;
-  let attached = !!(
-    nodeRootHost?.ownerDocument?.contains(nodeRootHost) ||
-    node?.ownerDocument?.contains(node)
-  );
+  let nodeRoot = node && getRootNode(node);
+  let nodeRootHost = nodeRoot?.host;
 
-  while (!attached && nodeRootHost) {
-    // since it's not attached and we have a root host, the node MUST be in a nested shadow DOM,
-    //  which means we need to get the host's host and check if that parent host is contained
-    //  in (i.e. attached to) the document
-    nodeRootHost = getRootNode(nodeRootHost).host;
-    attached = !!nodeRootHost?.ownerDocument?.contains(nodeRootHost);
+  // in some cases, a detached node will return itself as the root instead of a document or
+  //  shadow root object, in which case, we shouldn't try to look further up the host chain
+  let attached = false;
+  if (nodeRoot && nodeRoot !== node) {
+    attached = !!(
+      nodeRootHost?.ownerDocument?.contains(nodeRootHost) ||
+      node?.ownerDocument?.contains(node)
+    );
+
+    while (!attached && nodeRootHost) {
+      // since it's not attached and we have a root host, the node MUST be in a nested shadow DOM,
+      //  which means we need to get the host's host and check if that parent host is contained
+      //  in (i.e. attached to) the document
+      nodeRoot = getRootNode(nodeRootHost);
+      nodeRootHost = nodeRoot?.host;
+      attached = !!nodeRootHost?.ownerDocument?.contains(nodeRootHost);
+    }
   }
 
   return attached;

--- a/src/index.js
+++ b/src/index.js
@@ -272,10 +272,14 @@ const isNodeAttached = function (node) {
   //  to ignore the rootNode at this point, and use `node.ownerDocument`. Otherwise,
   //  using `rootNode.contains(node)` will _always_ be true we'll get false-positives when
   //  node is actually detached.
+  // NOTE: If `nodeRootHost` or `node` happens to be the `document` itself (which is possible
+  //  if a tabbable/focusable node was quickly added to the DOM, focused, and then removed
+  //  from the DOM as in https://github.com/focus-trap/focus-trap-react/issues/905), then
+  //  `ownerDocument` will be `null`, hence the optional chaining on it.
   let nodeRootHost = getRootNode(node).host;
   let attached = !!(
-    nodeRootHost?.ownerDocument.contains(nodeRootHost) ||
-    node.ownerDocument.contains(node)
+    nodeRootHost?.ownerDocument?.contains(nodeRootHost) ||
+    node.ownerDocument?.contains(node)
   );
 
   while (!attached && nodeRootHost) {

--- a/src/index.js
+++ b/src/index.js
@@ -276,10 +276,10 @@ const isNodeAttached = function (node) {
   //  if a tabbable/focusable node was quickly added to the DOM, focused, and then removed
   //  from the DOM as in https://github.com/focus-trap/focus-trap-react/issues/905), then
   //  `ownerDocument` will be `null`, hence the optional chaining on it.
-  let nodeRootHost = getRootNode(node).host;
+  let nodeRootHost = node && getRootNode(node).host;
   let attached = !!(
     nodeRootHost?.ownerDocument?.contains(nodeRootHost) ||
-    node.ownerDocument?.contains(node)
+    node?.ownerDocument?.contains(node)
   );
 
   while (!attached && nodeRootHost) {
@@ -287,7 +287,7 @@ const isNodeAttached = function (node) {
     //  which means we need to get the host's host and check if that parent host is contained
     //  in (i.e. attached to) the document
     nodeRootHost = getRootNode(nodeRootHost).host;
-    attached = !!nodeRootHost?.ownerDocument.contains(nodeRootHost);
+    attached = !!nodeRootHost?.ownerDocument?.contains(nodeRootHost);
   }
 
   return attached;


### PR DESCRIPTION
Fixes https://github.com/focus-trap/focus-trap-react/issues/905

There's a corner case where a node's `ownerDocument` could be null if
that node is itself the `document`, which could happen under special
circumstances.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
