### PR TITLE
[#292] Add support for inert attribute

### DIFF
--- a/.changeset/pretty-moons-teach.md
+++ b/.changeset/pretty-moons-teach.md
@@ -1,0 +1,5 @@
+---
+'tabbable': minor
+---
+
+Add support for new inert attribute ([#292](https://github.com/focus-trap/tabbable/issues/292))

--- a/.changeset/pretty-moons-teach.md
+++ b/.changeset/pretty-moons-teach.md
@@ -2,4 +2,4 @@
 'tabbable': minor
 ---
 
-Add support for new inert attribute ([#292](https://github.com/focus-trap/tabbable/issues/292))
+Add support for new [inert](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert#browser_compatibility) attribute ([#292](https://github.com/focus-trap/tabbable/issues/292))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,8 @@ jobs:
     timeout-minutes: 20
     container:
       # https://hub.docker.com/r/cypress/browsers/tags
-      image: cypress/browsers:node14.17.0-chrome88-ff89
+      # NOTE: at least Chrome 102 is required for testing `inert` attribute support
+      image: cypress/browsers:node-16.18.1-chrome-109.0.5414.74-1-ff-109.0-edge-109.0.1518.52-1
       options: --user 1001 --shm-size=2g # @see https://github.com/cypress-io/github-action/issues/104#issuecomment-666047965
     env:
       BABEL_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: yarn build
 
   E2E:
-    runs-on: ubuntu-20.04 # cypress/browsers image supports Ubuntu 18-20
+    runs-on: ubuntu-22.04
     name: e2e
     strategy:
       matrix:
@@ -65,7 +65,7 @@ jobs:
     container:
       # https://hub.docker.com/r/cypress/browsers/tags
       # NOTE: at least Chrome 102 is required for testing `inert` attribute support
-      image: cypress/browsers:node18.12.0-chrome103-ff107
+      image: cypress/browsers:node18.12.0-chrome106-ff106
       options: --user 1001 --shm-size=2g # @see https://github.com/cypress-io/github-action/issues/104#issuecomment-666047965
     env:
       BABEL_ENV: test
@@ -76,7 +76,7 @@ jobs:
       - name: Test E2E
         # https://github.com/cypress-io/github-action
         # https://github.com/cypress-io/code-coverage
-        uses: cypress-io/github-action@v4 # will run all tests found per cypress.config.js
+        uses: cypress-io/github-action@v5 # will run all tests found per cypress.config.js
         with:
           browser: ${{ matrix.browser }}
           env: coverage=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     container:
       # https://hub.docker.com/r/cypress/browsers/tags
       # NOTE: at least Chrome 102 is required for testing `inert` attribute support
-      image: cypress/browsers:node-16.18.1-chrome-109.0.5414.74-1-ff-109.0-edge-109.0.1518.52-1
+      image: cypress/browsers:node18.12.0-chrome103-ff107
       options: --user 1001 --shm-size=2g # @see https://github.com/cypress-io/github-action/issues/104#issuecomment-666047965
     env:
       BABEL_ENV: test

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Any of the above will _not_ be considered tabbable, though, if any of the follow
 - is nested under a closed `<details>` element (with the exception of the first `<summary>` element)
 - is an `<input type="radio">` element and a different radio in its group is `checked`
 - is a form field (button, input, select, textarea) inside a disabled `<fieldset>`
-- is [inert](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert) or in an inert container
+- is [inert](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert) or in an inert container
+    - ❗️ Only supported in [newer browsers](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert#browser_compatibility) that support this new attribute)
+    - ⚠️ Notably __not (yet) supported__ on Firefox and Safari (Feb 2023)
 
 **If you think a node should be included in your array of tabbables _but it's not_, all you need to do is add `tabindex="0"` to deliberately include it.** (Or if it is in your array but you don't want it, you can add `tabindex="-1"` to deliberately exclude it.) This will also result in more consistent cross-browser behavior. For information about why your special node might _not_ be included, see ["More details"](#more-details), below.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Any of the above will _not_ be considered tabbable, though, if any of the follow
 - is nested under a closed `<details>` element (with the exception of the first `<summary>` element)
 - is an `<input type="radio">` element and a different radio in its group is `checked`
 - is a form field (button, input, select, textarea) inside a disabled `<fieldset>`
+- is [inert](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert) or in an inert container
 
 **If you think a node should be included in your array of tabbables _but it's not_, all you need to do is add `tabindex="0"` to deliberately include it.** (Or if it is in your array but you don't want it, you can add `tabindex="-1"` to deliberately exclude it.) This will also result in more consistent cross-browser behavior. For information about why your special node might _not_ be included, see ["More details"](#more-details), below.
 
@@ -75,6 +76,7 @@ tabbable(rootNode, [options]);
     - All the [common options](#common-options).
     - `includeContainer: boolean` (default: false)
         - If set to `true`, `rootNode` will be included in the returned tabbable node array, if `rootNode` is tabbable.
+        - Note that whether this option is true or false, if the `rootNode` is [inert](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert), none of its children (deep) will be considered tabbable.
 
 Returns an array of ordered tabbable nodes (i.e. in tab order) within the `rootNode`.
 
@@ -97,6 +99,8 @@ isTabbable(node, [options]);
 
 Returns a boolean indicating whether the provided node is considered tabbable.
 
+> 💬 If the node has an [inert](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert) ancestor, it will not be tabbable.
+
 ### focusable
 
 ```js
@@ -110,6 +114,7 @@ focusable(rootNode, [options]);
     - All the [common options](#common-options).
     - `includeContainer: boolean` (default: false)
         - If set to `true`, `rootNode` will be included in the returned focusable node array, if `rootNode` is focusable.
+        - Note that whether this option is true or false, if the `rootNode` is [inert](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert), none of its children (deep) will be considered focusable.
 
 Returns an array of focusable nodes within the `rootNode`, in DOM order. This will not match the order in which `tabbable()` returns nodes.
 
@@ -127,7 +132,7 @@ isFocusable(node, [options]);
 
 Returns a boolean indicating whether the provided node is considered _focusable_.
 
-> 💬 All tabbable elements are focusable, but not all focusable elements are tabbable. For example, elements with `tabindex="-1"` are focusable but not tabbable.
+> 💬 All tabbable elements are focusable, but not all focusable elements are tabbable. For example, elements with `tabindex="-1"` are focusable but not tabbable. Also note that if the node has an[inert](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert) ancestor, it will not be focusable.
 
 ## Common Options
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,17 @@
+// separate `:not()` selectors has broader browser support than the newer
+//  `:not([inert], [inert] *)` (Feb 2023)
 const candidateSelectors = [
-  'input:not([inert] *)',
-  'select:not([inert] *)',
-  'textarea:not([inert] *)',
-  'a[href]:not([inert] *)',
-  'button:not([inert] *)',
-  '[tabindex]:not(slot):not([inert] *)',
-  'audio[controls]:not([inert] *)',
-  'video[controls]:not([inert] *)',
-  '[contenteditable]:not([contenteditable="false"]):not([inert] *)',
-  'details>summary:first-of-type:not([inert] *)',
-  'details:not([inert] *)',
+  'input:not([inert]):not([inert] *)',
+  'select:not([inert]):not([inert] *)',
+  'textarea:not([inert]):not([inert] *)',
+  'a[href]:not([inert]):not([inert] *)',
+  'button:not([inert]):not([inert] *)',
+  '[tabindex]:not(slot):not([inert]):not([inert] *)',
+  'audio[controls]:not([inert]):not([inert] *)',
+  'video[controls]:not([inert]):not([inert] *)',
+  '[contenteditable]:not([contenteditable="false"]):not([inert]):not([inert] *)',
+  'details>summary:first-of-type:not([inert]):not([inert] *)',
+  'details:not([inert]):not([inert] *)',
 ];
 const candidateSelector = /* #__PURE__ */ candidateSelectors.join(',');
 
@@ -35,6 +37,9 @@ const getRootNode =
  *  False if `node` is falsy.
  */
 const isInert = function (node, lookUp = true) {
+  // NOTE: this could also be handled with `node.matches('[inert], :is([inert] *)')`
+  //  if it weren't for `matches()` not being a function on shadow roots; the following
+  //  code works for any kind of node
   return !!(node?.inert || (lookUp && node && isInert(node.parentNode))); // recursive
 };
 

--- a/test/e2e/focusable.cy.js
+++ b/test/e2e/focusable.cy.js
@@ -106,6 +106,78 @@ describe('focusable', () => {
       });
     });
 
+    [undefined, 'full', 'legacy-full', 'non-zero-area', 'none'].forEach(
+      (displayCheck) => {
+        it(`correctly identifies focusable elements in the "inert" example with displayCheck=${
+          displayCheck || '<default>'
+        }`, () => {
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.inert;
+          document.body.append(container);
+
+          // non-inert container, but every element inside of it is
+          const focusableElements = focusable(container, { displayCheck });
+
+          expect(getIdsFromElementsArray(focusableElements)).to.eql([]);
+        });
+
+        it(`correctly identifies focusable elements in the "basic" example with displayCheck=${
+          displayCheck || '<default>'
+        } when placed directly inside an inert container`, () => {
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.basic;
+          container.inert = true;
+          document.body.append(container);
+
+          // inert container has non-inert children
+          const focusableElements = focusable(container, { displayCheck });
+
+          expect(getIdsFromElementsArray(focusableElements)).to.eql([]);
+        });
+
+        it(`correctly identifies focusable elements in the "basic" example with displayCheck=${
+          displayCheck || '<default>'
+        } when nested inside an inert container`, () => {
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.basic;
+          container.inert = true;
+
+          const parentContainer = document.createElement('div');
+          parentContainer.appendChild(container);
+          document.body.append(parentContainer);
+
+          // non-inert parent has inert container which has non-inert children
+          const focusableElements = focusable(parentContainer, {
+            displayCheck,
+          });
+
+          expect(getIdsFromElementsArray(focusableElements)).to.eql([]);
+        });
+
+        it(`correctly identifies focusable elements in the "basic" example with displayCheck=${
+          displayCheck || '<default>'
+        } when deeply nested inside an inert container`, () => {
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.basic;
+
+          const parentContainer = document.createElement('div');
+          parentContainer.inert = true;
+          parentContainer.appendChild(container);
+
+          const grandparentContainer = document.createElement('div');
+          grandparentContainer.appendChild(parentContainer);
+          document.body.append(grandparentContainer);
+
+          // non-inert grandparent has inert parent, which has non-container with children
+          const focusableElements = focusable(grandparentContainer, {
+            displayCheck,
+          });
+
+          expect(getIdsFromElementsArray(focusableElements)).to.eql([]);
+        });
+      }
+    );
+
     it('correctly identifies focusable elements in the "nested" example', () => {
       const expectedFocusableIds = [
         'tabindex-div-0',

--- a/test/e2e/focusable.cy.js
+++ b/test/e2e/focusable.cy.js
@@ -106,77 +106,80 @@ describe('focusable', () => {
       });
     });
 
-    [undefined, 'full', 'legacy-full', 'non-zero-area', 'none'].forEach(
-      (displayCheck) => {
-        it(`correctly identifies focusable elements in the "inert" example with displayCheck=${
-          displayCheck || '<default>'
-        }`, () => {
-          const container = document.createElement('div');
-          container.innerHTML = fixtures.inert;
-          document.body.append(container);
+    // TODO[ff-inert-support]: FF does not yet (Feb 2023) support the `inert` attribute
+    describe('inertness', { browser: '!firefox' }, () => {
+      [undefined, 'full', 'legacy-full', 'non-zero-area', 'none'].forEach(
+        (displayCheck) => {
+          it(`correctly identifies focusable elements in the "inert" example with displayCheck=${
+            displayCheck || '<default>'
+          }`, () => {
+            const container = document.createElement('div');
+            container.innerHTML = fixtures.inert;
+            document.body.append(container);
 
-          // non-inert container, but every element inside of it is
-          const focusableElements = focusable(container, { displayCheck });
+            // non-inert container, but every element inside of it is
+            const focusableElements = focusable(container, { displayCheck });
 
-          expect(getIdsFromElementsArray(focusableElements)).to.eql([]);
-        });
-
-        it(`correctly identifies focusable elements in the "basic" example with displayCheck=${
-          displayCheck || '<default>'
-        } when placed directly inside an inert container`, () => {
-          const container = document.createElement('div');
-          container.innerHTML = fixtures.basic;
-          container.inert = true;
-          document.body.append(container);
-
-          // inert container has non-inert children
-          const focusableElements = focusable(container, { displayCheck });
-
-          expect(getIdsFromElementsArray(focusableElements)).to.eql([]);
-        });
-
-        it(`correctly identifies focusable elements in the "basic" example with displayCheck=${
-          displayCheck || '<default>'
-        } when nested inside an inert container`, () => {
-          const container = document.createElement('div');
-          container.innerHTML = fixtures.basic;
-          container.inert = true;
-
-          const parentContainer = document.createElement('div');
-          parentContainer.appendChild(container);
-          document.body.append(parentContainer);
-
-          // non-inert parent has inert container which has non-inert children
-          const focusableElements = focusable(parentContainer, {
-            displayCheck,
+            expect(getIdsFromElementsArray(focusableElements)).to.eql([]);
           });
 
-          expect(getIdsFromElementsArray(focusableElements)).to.eql([]);
-        });
+          it(`correctly identifies focusable elements in the "basic" example with displayCheck=${
+            displayCheck || '<default>'
+          } when placed directly inside an inert container`, () => {
+            const container = document.createElement('div');
+            container.innerHTML = fixtures.basic;
+            container.inert = true;
+            document.body.append(container);
 
-        it(`correctly identifies focusable elements in the "basic" example with displayCheck=${
-          displayCheck || '<default>'
-        } when deeply nested inside an inert container`, () => {
-          const container = document.createElement('div');
-          container.innerHTML = fixtures.basic;
+            // inert container has non-inert children
+            const focusableElements = focusable(container, { displayCheck });
 
-          const parentContainer = document.createElement('div');
-          parentContainer.inert = true;
-          parentContainer.appendChild(container);
-
-          const grandparentContainer = document.createElement('div');
-          grandparentContainer.appendChild(parentContainer);
-          document.body.append(grandparentContainer);
-
-          // non-inert grandparent has inert parent, which has non-container with children
-          const focusableElements = focusable(grandparentContainer, {
-            displayCheck,
+            expect(getIdsFromElementsArray(focusableElements)).to.eql([]);
           });
 
-          expect(getIdsFromElementsArray(focusableElements)).to.eql([]);
-        });
-      }
-    );
+          it(`correctly identifies focusable elements in the "basic" example with displayCheck=${
+            displayCheck || '<default>'
+          } when nested inside an inert container`, () => {
+            const container = document.createElement('div');
+            container.innerHTML = fixtures.basic;
+            container.inert = true;
+
+            const parentContainer = document.createElement('div');
+            parentContainer.appendChild(container);
+            document.body.append(parentContainer);
+
+            // non-inert parent has inert container which has non-inert children
+            const focusableElements = focusable(parentContainer, {
+              displayCheck,
+            });
+
+            expect(getIdsFromElementsArray(focusableElements)).to.eql([]);
+          });
+
+          it(`correctly identifies focusable elements in the "basic" example with displayCheck=${
+            displayCheck || '<default>'
+          } when deeply nested inside an inert container`, () => {
+            const container = document.createElement('div');
+            container.innerHTML = fixtures.basic;
+
+            const parentContainer = document.createElement('div');
+            parentContainer.inert = true;
+            parentContainer.appendChild(container);
+
+            const grandparentContainer = document.createElement('div');
+            grandparentContainer.appendChild(parentContainer);
+            document.body.append(grandparentContainer);
+
+            // non-inert grandparent has inert parent, which has non-container with children
+            const focusableElements = focusable(grandparentContainer, {
+              displayCheck,
+            });
+
+            expect(getIdsFromElementsArray(focusableElements)).to.eql([]);
+          });
+        }
+      );
+    });
 
     it('correctly identifies focusable elements in the "nested" example', () => {
       const expectedFocusableIds = [

--- a/test/e2e/isFocusable.cy.js
+++ b/test/e2e/isFocusable.cy.js
@@ -421,7 +421,8 @@ describe('isFocusable', () => {
       ).to.eql(true);
     });
 
-    describe('inertness', () => {
+    // TODO[ff-inert-support]: FF does not yet (Feb 2023) support the `inert` attribute
+    describe('inertness', { browser: '!firefox' }, () => {
       it('returns false for any inert element', () => {
         const container = document.createElement('div');
         container.innerHTML = fixtures.inert;

--- a/test/e2e/isFocusable.cy.js
+++ b/test/e2e/isFocusable.cy.js
@@ -420,6 +420,43 @@ describe('isFocusable', () => {
         isFocusable(getByTestId(container, 'fieldset-disabled-anchor'))
       ).to.eql(true);
     });
+
+    describe('inertness', () => {
+      it('returns false for any inert element', () => {
+        const container = document.createElement('div');
+        container.innerHTML = fixtures.inert;
+        document.body.append(container);
+
+        for (const child of container.children) {
+          expect(isFocusable(child)).to.eql(false);
+        }
+      });
+
+      it('returns false for any element inside an inert parent', () => {
+        const container = document.createElement('div');
+        container.innerHTML = fixtures.basic;
+        container.inert = true;
+        document.body.append(container);
+
+        for (const child of container.children) {
+          expect(isFocusable(child), child.id).to.eql(false);
+        }
+      });
+
+      it('returns false for any element inside an inert ancestor', () => {
+        const container = document.createElement('div');
+        container.innerHTML = fixtures.basic;
+
+        const parent = document.createElement('div');
+        parent.inert = true;
+        parent.appendChild(container);
+        document.body.append(parent);
+
+        for (const child of container.children) {
+          expect(isFocusable(child), child.id).to.eql(false);
+        }
+      });
+    });
   });
 
   describe('display check', () => {

--- a/test/e2e/isTabbable.cy.js
+++ b/test/e2e/isTabbable.cy.js
@@ -407,6 +407,43 @@ describe('isTabbable', () => {
         isTabbable(getByTestId(container, 'fieldset-disabled-anchor'))
       ).to.eql(true);
     });
+
+    describe('inertness', () => {
+      it('returns false for any inert element', () => {
+        const container = document.createElement('div');
+        container.innerHTML = fixtures.inert;
+        document.body.append(container);
+
+        for (const child of container.children) {
+          expect(isTabbable(child)).to.eql(false);
+        }
+      });
+
+      it('returns false for any element inside an inert parent', () => {
+        const container = document.createElement('div');
+        container.innerHTML = fixtures.basic;
+        container.inert = true;
+        document.body.append(container);
+
+        for (const child of container.children) {
+          expect(isTabbable(child), child.id).to.eql(false);
+        }
+      });
+
+      it('returns false for any element inside an inert ancestor', () => {
+        const container = document.createElement('div');
+        container.innerHTML = fixtures.basic;
+
+        const parent = document.createElement('div');
+        parent.inert = true;
+        parent.appendChild(container);
+        document.body.append(parent);
+
+        for (const child of container.children) {
+          expect(isTabbable(child), child.id).to.eql(false);
+        }
+      });
+    });
   });
 
   describe('display check', () => {

--- a/test/e2e/isTabbable.cy.js
+++ b/test/e2e/isTabbable.cy.js
@@ -408,7 +408,8 @@ describe('isTabbable', () => {
       ).to.eql(true);
     });
 
-    describe('inertness', () => {
+    // TODO[ff-inert-support]: FF does not yet (Feb 2023) support the `inert` attribute
+    describe('inertness', { browser: '!firefox' }, () => {
       it('returns false for any inert element', () => {
         const container = document.createElement('div');
         container.innerHTML = fixtures.inert;

--- a/test/e2e/shadow-dom.cy.js
+++ b/test/e2e/shadow-dom.cy.js
@@ -166,526 +166,542 @@ describe('web-components', () => {
   });
 
   describe('tabbable/focusable', () => {
+    describe('common', () => {
+      it('should not find elements inside shadow dom that browsers will skip due to -1 tabindex on host', () => {
+        const expected = [];
+        const { container } = setupFixture(fixtures['shadow-dom-untabbable'], {
+          window,
+        });
+        const shadowElement = container.querySelector('test-shadow');
+
+        let result = tabbable(shadowElement, { getShadowRoot() {} });
+        expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+          expected
+        );
+
+        result = tabbable(shadowElement, { getShadowRoot: true });
+        expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+          expected
+        );
+      });
+
+      it('should sort shadow and light elements separately', () => {
+        const expected = [
+          'light-first',
+          'light-middle',
+          'light-last',
+          'shadow-first',
+          'shadow-middle',
+          'shadow-last',
+        ];
+        const { container } = setupFixture(fixtures.shadowDomQuery, {
+          window,
+          caseId: 'light-shadow-tab-index',
+        });
+
+        let result = tabbable(container, { getShadowRoot() {} });
+        expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+          expected
+        );
+
+        result = tabbable(container, { getShadowRoot() {} });
+        expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+          expected
+        );
+      });
+
+      it('should sort slots content by slots tabindex', () => {
+        const { container } = setupFixture(fixtures.shadowDomQuery, {
+          window,
+          caseId: 'slots-tab-index',
+        });
+
+        let tabbableList = tabbable(container, { getShadowRoot() {} });
+        let focusableList = focusable(container, { getShadowRoot() {} });
+
+        expect(
+          getIdsFromElementsArray(tabbableList),
+          'tabbable, using `() => {}`'
+        ).to.eql([
+          'light-1',
+          'shadow-1',
+          'shadow-2',
+          'light-2',
+          'shadow-3',
+          'light-3',
+        ]);
+        expect(
+          getIdsFromElementsArray(focusableList),
+          'focusable, using `() => {}`'
+        ).to.eql([
+          'shadow-3',
+          'light-3',
+          'light-2',
+          'light-1',
+          'shadow-2',
+          'shadow-1',
+        ]);
+
+        tabbableList = tabbable(container, { getShadowRoot: true });
+        focusableList = focusable(container, { getShadowRoot: true });
+
+        expect(
+          getIdsFromElementsArray(tabbableList),
+          'tabbable, using `true`'
+        ).to.eql([
+          'light-1',
+          'shadow-1',
+          'shadow-2',
+          'light-2',
+          'shadow-3',
+          'light-3',
+        ]);
+        expect(
+          getIdsFromElementsArray(focusableList),
+          'focusable, using `true`'
+        ).to.eql([
+          'shadow-3',
+          'light-3',
+          'light-2',
+          'light-1',
+          'shadow-2',
+          'shadow-1',
+        ]);
+      });
+
+      it('should insert slots nested content according to slot positions', () => {
+        const expected = [
+          'light-1',
+          'light-2',
+          'light-3',
+          'shadow-between',
+          'light-4',
+          'light-5',
+          'light-6',
+        ];
+        const { container } = setupFixture(fixtures.shadowDomQuery, {
+          window,
+          caseId: 'slots-nested-tab-index',
+        });
+
+        let result = tabbable(container, { getShadowRoot() {} });
+        expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+          expected
+        );
+
+        result = tabbable(container, { getShadowRoot: true });
+        expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+          expected
+        );
+      });
+
+      // (i.e. slot with tabindex should be ignored; only slotted element should be found)
+      it('should not find slot with tabindex', () => {
+        const expected = ['light-slotter-before'];
+        const { container } = setupFixture(fixtures.shadowDomQuery, {
+          window,
+          caseId: 'light-shadow-with-slots',
+        });
+        const shadowElement = container.querySelector('test-shadow');
+        const slot = shadowElement.shadowRoot.querySelector(
+          'slot[name="before"]'
+        );
+        slot.id = 'slot-id';
+        slot.tabIndex = '1';
+
+        let result = tabbable(slot, { getShadowRoot() {} });
+        expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+          expected
+        );
+
+        result = tabbable(slot, { getShadowRoot: true });
+        expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+          expected
+        );
+      });
+
+      it('should filter un-tabbable elements', () => {
+        const expected = [
+          'shadow-summary',
+          'shadow-details-without-summary',
+          'shadow-radio-checked',
+        ];
+        const { container } = setupFixture(fixtures.shadowDomQuery, {
+          window,
+          caseId: 'filter-conditions',
+        });
+
+        let result = tabbable(container, { getShadowRoot() {} });
+        expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+          expected
+        );
+
+        result = tabbable(container, { getShadowRoot: true });
+        expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+          expected
+        );
+      });
+
+      it('should filter un-focusable elements', () => {
+        const expected = [
+          'shadow-summary',
+          'shadow-details-without-summary',
+          'shadow-radio-unchecked',
+          'shadow-radio-checked',
+          'shadow-negative-tabindex',
+        ];
+        const { container } = setupFixture(fixtures.shadowDomQuery, {
+          window,
+          caseId: 'filter-conditions',
+        });
+
+        let result = focusable(container, { getShadowRoot() {} });
+        expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+          expected
+        );
+
+        result = focusable(container, { getShadowRoot: true });
+        expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+          expected
+        );
+      });
+
+      // NOTE: this test shows that tabbable() and focusable() will not find
+      //  query-light-input-slotted whether we give the closed shadow root to look at
+      //  or not, because it's slotted into a 'display: none' container inside
+      //  the close shadow dom
+      it('should not match elements in a non display slot', () => {
+        const expected = [];
+        const { container } = setupFixture(fixtures.shadowDomQuery, {
+          window,
+          caseId: 'query-slot-display-none-closed-shadow',
+        });
+
+        expect(
+          getIdsFromElementsArray(
+            focusable(container),
+            'focusable no options (shadow support disabled) should not find'
+          )
+        ).to.eql(expected);
+
+        expect(
+          getIdsFromElementsArray(
+            focusable(container, {
+              getShadowRoot(node) {
+                return node.closedShadowRoot;
+              },
+            }),
+            'focusable with options should not find because slot container is hidden'
+          )
+        ).to.eql(expected);
+
+        expect(
+          getIdsFromElementsArray(
+            tabbable(container),
+            'tabbable no options (shadow support disabled) should not find'
+          )
+        ).to.eql(expected);
+
+        expect(
+          getIdsFromElementsArray(
+            tabbable(container, {
+              getShadowRoot(node) {
+                return node.closedShadowRoot;
+              },
+            }),
+            'tabbable with options should not find because slot container is hidden'
+          )
+        ).to.eql(expected);
+      });
+    });
+
     [false, true].forEach((inertTest) => {
-      describe(`${inertTest ? 'inertness' : 'activeness'}`, () => {
-        it(`should${inertTest ? ' not' : ''} find${
-          inertTest ? ' inert' : ''
-        } elements inside shadow dom`, () => {
-          const expected = inertTest
-            ? ['light-before', 'light-after']
-            : ['light-before', 'shadow-input', 'light-after'];
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: inertTest ? 'inert-shadow-input' : 'shadow-input',
-          });
+      // TODO[ff-inert-support]: FF does not yet (Feb 2023) support the `inert` attribute
+      describe(
+        `${inertTest ? 'inertness' : 'activeness'}`,
+        { browser: inertTest ? '!firefox' : undefined },
+        () => {
+          it(
+            `should${inertTest ? ' not' : ''} find${
+              inertTest ? ' inert' : ''
+            } elements inside shadow dom`,
+            { browser: '!chrome' },
+            () => {
+              const expected = inertTest
+                ? ['light-before', 'light-after']
+                : ['light-before', 'shadow-input', 'light-after'];
+              const { container } = setupFixture(fixtures.shadowDomQuery, {
+                window,
+                caseId: inertTest ? 'inert-shadow-input' : 'shadow-input',
+              });
 
-          let result = tabbable(container, { getShadowRoot() {} });
-          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-            expected
-          );
+              let result = tabbable(container, { getShadowRoot() {} });
+              expect(
+                getIdsFromElementsArray(result),
+                'using `() => {}`'
+              ).to.eql(expected);
 
-          result = tabbable(container, { getShadowRoot: true });
-          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
-            expected
-          );
-        });
-
-        it(`should${inertTest ? ' not' : ''} find${
-          inertTest ? ' inert' : ''
-        } tabbable host`, () => {
-          const expected = inertTest
-            ? ['light-before', 'light-after']
-            : ['light-before', 'tabbable-host', 'shadow-input', 'light-after'];
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: inertTest ? 'inert-tabbable-host' : 'tabbable-host',
-          });
-
-          let result = tabbable(container, { getShadowRoot() {} });
-          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-            expected
-          );
-
-          result = tabbable(container, { getShadowRoot: true });
-          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
-            expected
-          );
-        });
-
-        // make sure we're not conflicting with valid `scope` attribute on <th> elements
-        //  when we're sorting nodes in tab order (we don't test focusable() because
-        //  there's no focus order)
-        it(`should${inertTest ? ' not' : ''} find${
-          inertTest ? ' inert' : ''
-        } tabbable scoped headers`, () => {
-          const expected = inertTest
-            ? []
-            : [
-                'header-athlete-col',
-                'header-swim-col',
-                'header-bike-col',
-                'header-run-col',
-              ];
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: inertTest
-              ? 'table-with-inert-tabbable-scoped-headers'
-              : 'table-with-tabbable-scoped-headers',
-          });
-
-          const result = tabbable(container);
-          expect(getIdsFromElementsArray(result), 'tabbable').to.eql(expected);
-        });
-
-        it(`should${
-          inertTest ? ' not' : ''
-        } find elements inside shadow dom when directly querying the${
-          inertTest ? ' inert' : ''
-        } element with shadow root`, () => {
-          const expected = inertTest ? [] : ['shadow-input'];
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: 'shadow-input',
-          });
-          const shadowElement = container.querySelector('test-shadow');
-          shadowElement.inert = inertTest;
-
-          let result = tabbable(shadowElement, { getShadowRoot() {} });
-          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-            expected
-          );
-
-          result = tabbable(shadowElement, { getShadowRoot: true });
-          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
-            expected
-          );
-        });
-
-        it(`should${
-          inertTest ? ' not' : ''
-        } find elements inside shadow dom when directly querying the${
-          inertTest ? ' inert' : ''
-        } element with shadow root (include container)`, () => {
-          const expected = inertTest ? [] : ['shadow-host', 'shadow-input'];
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: 'shadow-input',
-          });
-          const shadowElement = container.querySelector('test-shadow');
-          shadowElement.setAttribute('id', 'shadow-host');
-          shadowElement.setAttribute('tabindex', 0);
-          shadowElement.inert = inertTest;
-
-          let result = tabbable(shadowElement, {
-            getShadowRoot() {},
-            includeContainer: true,
-          });
-          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-            expected
-          );
-
-          result = tabbable(shadowElement, {
-            getShadowRoot: true,
-            includeContainer: true,
-          });
-          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
-            expected
-          );
-        });
-
-        it('should not find elements inside shadow dom that browsers will skip due to -1 tabindex on host', () => {
-          const expected = [];
-          const { container } = setupFixture(
-            fixtures['shadow-dom-untabbable'],
-            {
-              window,
+              result = tabbable(container, { getShadowRoot: true });
+              expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+                expected
+              );
             }
           );
-          const shadowElement = container.querySelector('test-shadow');
 
-          let result = tabbable(shadowElement, { getShadowRoot() {} });
-          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-            expected
-          );
+          it(`should${inertTest ? ' not' : ''} find${
+            inertTest ? ' inert' : ''
+          } tabbable host`, () => {
+            const expected = inertTest
+              ? ['light-before', 'light-after']
+              : [
+                  'light-before',
+                  'tabbable-host',
+                  'shadow-input',
+                  'light-after',
+                ];
+            const { container } = setupFixture(fixtures.shadowDomQuery, {
+              window,
+              caseId: inertTest ? 'inert-tabbable-host' : 'tabbable-host',
+            });
 
-          result = tabbable(shadowElement, { getShadowRoot: true });
-          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
-            expected
-          );
-        });
+            let result = tabbable(container, { getShadowRoot() {} });
+            expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+              expected
+            );
 
-        // NOTE: the inert attribute on a <slot> is either inherited by the slotted element,
-        //  or respected by the browser as an inert ancestor (either way, the slotted element
-        //  ends-up inert too)
-        it(`should${
-          inertTest ? ' ignore inert' : ' sort'
-        } slots inside shadow dom`, () => {
-          const expected = inertTest
-            ? ['light-before', 'shadow-input', 'light-after']
-            : [
-                'light-before',
-                'light-slotter-before',
-                'shadow-input',
-                'light-slotter-after',
-                'light-slotter-default',
-                'default-slot-input',
-                'light-after',
-              ];
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: inertTest
-              ? 'light-shadow-with-inert-slots'
-              : 'light-shadow-with-slots',
+            result = tabbable(container, { getShadowRoot: true });
+            expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+              expected
+            );
           });
 
-          let result = tabbable(container, { getShadowRoot() {} });
-          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-            expected
-          );
+          // make sure we're not conflicting with valid `scope` attribute on <th> elements
+          //  when we're sorting nodes in tab order (we don't test focusable() because
+          //  there's no focus order)
+          it(`should${inertTest ? ' not' : ''} find${
+            inertTest ? ' inert' : ''
+          } tabbable scoped headers`, () => {
+            const expected = inertTest
+              ? []
+              : [
+                  'header-athlete-col',
+                  'header-swim-col',
+                  'header-bike-col',
+                  'header-run-col',
+                ];
+            const { container } = setupFixture(fixtures.shadowDomQuery, {
+              window,
+              caseId: inertTest
+                ? 'table-with-inert-tabbable-scoped-headers'
+                : 'table-with-tabbable-scoped-headers',
+            });
 
-          result = tabbable(container, { getShadowRoot: true });
-          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
-            expected
-          );
-        });
-
-        it('should sort shadow and light elements separately', () => {
-          const expected = [
-            'light-first',
-            'light-middle',
-            'light-last',
-            'shadow-first',
-            'shadow-middle',
-            'shadow-last',
-          ];
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: 'light-shadow-tab-index',
+            const result = tabbable(container);
+            expect(getIdsFromElementsArray(result), 'tabbable').to.eql(
+              expected
+            );
           });
 
-          let result = tabbable(container, { getShadowRoot() {} });
-          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-            expected
-          );
+          it(`should${
+            inertTest ? ' not' : ''
+          } find elements inside shadow dom when directly querying the${
+            inertTest ? ' inert' : ''
+          } element with shadow root`, () => {
+            const expected = inertTest ? [] : ['shadow-input'];
+            const { container } = setupFixture(fixtures.shadowDomQuery, {
+              window,
+              caseId: 'shadow-input',
+            });
+            const shadowElement = container.querySelector('test-shadow');
+            shadowElement.inert = inertTest;
 
-          result = tabbable(container, { getShadowRoot() {} });
-          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
-            expected
-          );
-        });
+            let result = tabbable(shadowElement, { getShadowRoot() {} });
+            expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+              expected
+            );
 
-        it('should sort slots content by slots tabindex', () => {
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: 'slots-tab-index',
+            result = tabbable(shadowElement, { getShadowRoot: true });
+            expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+              expected
+            );
           });
 
-          let tabbableList = tabbable(container, { getShadowRoot() {} });
-          let focusableList = focusable(container, { getShadowRoot() {} });
+          it(`should${
+            inertTest ? ' not' : ''
+          } find elements inside shadow dom when directly querying the${
+            inertTest ? ' inert' : ''
+          } element with shadow root (include container)`, () => {
+            const expected = inertTest ? [] : ['shadow-host', 'shadow-input'];
+            const { container } = setupFixture(fixtures.shadowDomQuery, {
+              window,
+              caseId: 'shadow-input',
+            });
+            const shadowElement = container.querySelector('test-shadow');
+            shadowElement.setAttribute('id', 'shadow-host');
+            shadowElement.setAttribute('tabindex', 0);
+            shadowElement.inert = inertTest;
 
-          expect(
-            getIdsFromElementsArray(tabbableList),
-            'tabbable, using `() => {}`'
-          ).to.eql([
-            'light-1',
-            'shadow-1',
-            'shadow-2',
-            'light-2',
-            'shadow-3',
-            'light-3',
-          ]);
-          expect(
-            getIdsFromElementsArray(focusableList),
-            'focusable, using `() => {}`'
-          ).to.eql([
-            'shadow-3',
-            'light-3',
-            'light-2',
-            'light-1',
-            'shadow-2',
-            'shadow-1',
-          ]);
+            let result = tabbable(shadowElement, {
+              getShadowRoot() {},
+              includeContainer: true,
+            });
+            expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+              expected
+            );
 
-          tabbableList = tabbable(container, { getShadowRoot: true });
-          focusableList = focusable(container, { getShadowRoot: true });
-
-          expect(
-            getIdsFromElementsArray(tabbableList),
-            'tabbable, using `true`'
-          ).to.eql([
-            'light-1',
-            'shadow-1',
-            'shadow-2',
-            'light-2',
-            'shadow-3',
-            'light-3',
-          ]);
-          expect(
-            getIdsFromElementsArray(focusableList),
-            'focusable, using `true`'
-          ).to.eql([
-            'shadow-3',
-            'light-3',
-            'light-2',
-            'light-1',
-            'shadow-2',
-            'shadow-1',
-          ]);
-        });
-
-        it('should insert slots nested content according to slot positions', () => {
-          const expected = [
-            'light-1',
-            'light-2',
-            'light-3',
-            'shadow-between',
-            'light-4',
-            'light-5',
-            'light-6',
-          ];
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: 'slots-nested-tab-index',
+            result = tabbable(shadowElement, {
+              getShadowRoot: true,
+              includeContainer: true,
+            });
+            expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+              expected
+            );
           });
 
-          let result = tabbable(container, { getShadowRoot() {} });
-          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-            expected
-          );
+          // NOTE: the inert attribute on a <slot> is either inherited by the slotted element,
+          //  or respected by the browser as an inert ancestor (either way, the slotted element
+          //  ends-up inert too)
+          it(`should${
+            inertTest ? ' ignore inert' : ' sort'
+          } slots inside shadow dom`, () => {
+            const expected = inertTest
+              ? ['light-before', 'shadow-input', 'light-after']
+              : [
+                  'light-before',
+                  'light-slotter-before',
+                  'shadow-input',
+                  'light-slotter-after',
+                  'light-slotter-default',
+                  'default-slot-input',
+                  'light-after',
+                ];
+            const { container } = setupFixture(fixtures.shadowDomQuery, {
+              window,
+              caseId: inertTest
+                ? 'light-shadow-with-inert-slots'
+                : 'light-shadow-with-slots',
+            });
 
-          result = tabbable(container, { getShadowRoot: true });
-          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
-            expected
-          );
-        });
+            let result = tabbable(container, { getShadowRoot() {} });
+            expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+              expected
+            );
 
-        it(`should query nested shadow doms for slots${
-          inertTest ? ' (inert test)' : ''
-        }`, () => {
-          const expected = inertTest
-            ? ['shadow-outter-before', 'shadow-inner', 'shadow-outter-after']
-            : [
-                'shadow-outter-before',
-                'shadow-inner',
-                'light-slotted-input',
-                'shadow-outter-after',
-              ];
-
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: inertTest
-              ? 'inert-slotted-through-multiple-shadows'
-              : 'slotted-through-multiple-shadows',
+            result = tabbable(container, { getShadowRoot: true });
+            expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+              expected
+            );
           });
 
-          let result = tabbable(container, { getShadowRoot() {} });
-          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-            expected
-          );
+          it(`should query nested shadow doms for slots${
+            inertTest ? ' (inert test)' : ''
+          }`, () => {
+            const expected = inertTest
+              ? ['shadow-outter-before', 'shadow-inner', 'shadow-outter-after']
+              : [
+                  'shadow-outter-before',
+                  'shadow-inner',
+                  'light-slotted-input',
+                  'shadow-outter-after',
+                ];
 
-          result = tabbable(container, { getShadowRoot: true });
-          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
-            expected
-          );
-        });
+            const { container } = setupFixture(fixtures.shadowDomQuery, {
+              window,
+              caseId: inertTest
+                ? 'inert-slotted-through-multiple-shadows'
+                : 'slotted-through-multiple-shadows',
+            });
 
-        it(`should${inertTest ? ' not' : ''} find elements inside${
-          inertTest ? ' inert' : ''
-        } slot`, () => {
-          const expected = inertTest ? [] : ['light-slotter-before'];
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: inertTest
-              ? 'light-shadow-with-inert-slots'
-              : 'light-shadow-with-slots',
-          });
-          const shadowElement = container.querySelector('test-shadow');
-          const slot = shadowElement.shadowRoot.querySelector(
-            'slot[name="before"]'
-          );
+            let result = tabbable(container, { getShadowRoot() {} });
+            expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+              expected
+            );
 
-          let result = tabbable(slot, { getShadowRoot() {} });
-          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-            expected
-          );
-
-          result = tabbable(slot, { getShadowRoot: true });
-          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
-            expected
-          );
-        });
-
-        // (i.e. slot with tabindex should be ignored; only slotted element should be found)
-        it('should not find slot with tabindex', () => {
-          const expected = ['light-slotter-before'];
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: 'light-shadow-with-slots',
-          });
-          const shadowElement = container.querySelector('test-shadow');
-          const slot = shadowElement.shadowRoot.querySelector(
-            'slot[name="before"]'
-          );
-          slot.id = 'slot-id';
-          slot.tabIndex = '1';
-
-          let result = tabbable(slot, { getShadowRoot() {} });
-          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-            expected
-          );
-
-          result = tabbable(slot, { getShadowRoot: true });
-          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
-            expected
-          );
-        });
-
-        it('should filter un-tabbable elements', () => {
-          const expected = [
-            'shadow-summary',
-            'shadow-details-without-summary',
-            'shadow-radio-checked',
-          ];
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: 'filter-conditions',
+            result = tabbable(container, { getShadowRoot: true });
+            expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+              expected
+            );
           });
 
-          let result = tabbable(container, { getShadowRoot() {} });
-          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-            expected
-          );
+          it(`should${inertTest ? ' not' : ''} find elements inside${
+            inertTest ? ' inert' : ''
+          } slot`, () => {
+            const expected = inertTest ? [] : ['light-slotter-before'];
+            const { container } = setupFixture(fixtures.shadowDomQuery, {
+              window,
+              caseId: inertTest
+                ? 'light-shadow-with-inert-slots'
+                : 'light-shadow-with-slots',
+            });
+            const shadowElement = container.querySelector('test-shadow');
+            const slot = shadowElement.shadowRoot.querySelector(
+              'slot[name="before"]'
+            );
 
-          result = tabbable(container, { getShadowRoot: true });
-          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
-            expected
-          );
-        });
+            let result = tabbable(slot, { getShadowRoot() {} });
+            expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+              expected
+            );
 
-        it('should filter un-focusable elements', () => {
-          const expected = [
-            'shadow-summary',
-            'shadow-details-without-summary',
-            'shadow-radio-unchecked',
-            'shadow-radio-checked',
-            'shadow-negative-tabindex',
-          ];
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: 'filter-conditions',
+            result = tabbable(slot, { getShadowRoot: true });
+            expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+              expected
+            );
           });
 
-          let result = focusable(container, { getShadowRoot() {} });
-          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-            expected
-          );
+          it(`should accept shadow root in order to query closed shadows${
+            inertTest ? ' (inert test)' : ''
+          }`, () => {
+            const { container } = setupFixture(fixtures.shadowDomQuery, {
+              window,
+              caseId: inertTest
+                ? 'closed-inert-shadow-input'
+                : 'closed-shadow-input',
+            });
 
-          result = focusable(container, { getShadowRoot: true });
-          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
-            expected
-          );
-        });
+            const providedShadowRoot = tabbable(container, {
+              getShadowRoot(node) {
+                return node.closedShadowRoot;
+              },
+            });
+            const noKnowlegeOfShadowRootFn = tabbable(container, {
+              getShadowRoot(_node) {
+                return false;
+              },
+            });
+            const noKnowlegeOfShadowRootTrue = tabbable(container, {
+              getShadowRoot: true,
+            });
+            const undisclosedShadowRoot = tabbable(container, {
+              getShadowRoot(_node) {
+                return true;
+              },
+            });
 
-        it(`should accept shadow root in order to query closed shadows${
-          inertTest ? ' (inert test)' : ''
-        }`, () => {
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: inertTest
-              ? 'closed-inert-shadow-input'
-              : 'closed-shadow-input',
+            expect(
+              getIdsFromElementsArray(providedShadowRoot),
+              'provided shadow root'
+            ).to.eql([
+              'light-before',
+              ...(inertTest ? [] : ['shadow-input']),
+              'light-slotted',
+              'light-after',
+            ]);
+            expect(
+              getIdsFromElementsArray(noKnowlegeOfShadowRootFn),
+              'no knowledge of shadow root, using `() => false`'
+            ).to.eql(['light-slotted', 'light-before', 'light-after']);
+            expect(
+              getIdsFromElementsArray(noKnowlegeOfShadowRootTrue),
+              'no knowledge of shadow root, using `true`'
+            ).to.eql(getIdsFromElementsArray(noKnowlegeOfShadowRootFn));
+            expect(
+              getIdsFromElementsArray(undisclosedShadowRoot),
+              'undisclosed shadow root'
+            ).to.eql(['light-before', 'light-slotted', 'light-after']);
           });
-
-          const providedShadowRoot = tabbable(container, {
-            getShadowRoot(node) {
-              return node.closedShadowRoot;
-            },
-          });
-          const noKnowlegeOfShadowRootFn = tabbable(container, {
-            getShadowRoot(_node) {
-              return false;
-            },
-          });
-          const noKnowlegeOfShadowRootTrue = tabbable(container, {
-            getShadowRoot: true,
-          });
-          const undisclosedShadowRoot = tabbable(container, {
-            getShadowRoot(_node) {
-              return true;
-            },
-          });
-
-          expect(
-            getIdsFromElementsArray(providedShadowRoot),
-            'provided shadow root'
-          ).to.eql([
-            'light-before',
-            ...(inertTest ? [] : ['shadow-input']),
-            'light-slotted',
-            'light-after',
-          ]);
-          expect(
-            getIdsFromElementsArray(noKnowlegeOfShadowRootFn),
-            'no knowledge of shadow root, using `() => false`'
-          ).to.eql(['light-slotted', 'light-before', 'light-after']);
-          expect(
-            getIdsFromElementsArray(noKnowlegeOfShadowRootTrue),
-            'no knowledge of shadow root, using `true`'
-          ).to.eql(getIdsFromElementsArray(noKnowlegeOfShadowRootFn));
-          expect(
-            getIdsFromElementsArray(undisclosedShadowRoot),
-            'undisclosed shadow root'
-          ).to.eql(['light-before', 'light-slotted', 'light-after']);
-        });
-
-        // NOTE: this test shows that tabbable() and focusable() will not find
-        //  query-light-input-slotted whether we give the closed shadow root to look at
-        //  or not, because it's slotted into a 'display: none' container inside
-        //  the close shadow dom
-        it('should not match elements in a non display slot', () => {
-          const expected = [];
-          const { container } = setupFixture(fixtures.shadowDomQuery, {
-            window,
-            caseId: 'query-slot-display-none-closed-shadow',
-          });
-
-          expect(
-            getIdsFromElementsArray(
-              focusable(container),
-              'focusable no options (shadow support disabled) should not find'
-            )
-          ).to.eql(expected);
-
-          expect(
-            getIdsFromElementsArray(
-              focusable(container, {
-                getShadowRoot(node) {
-                  return node.closedShadowRoot;
-                },
-              }),
-              'focusable with options should not find because slot container is hidden'
-            )
-          ).to.eql(expected);
-
-          expect(
-            getIdsFromElementsArray(
-              tabbable(container),
-              'tabbable no options (shadow support disabled) should not find'
-            )
-          ).to.eql(expected);
-
-          expect(
-            getIdsFromElementsArray(
-              tabbable(container, {
-                getShadowRoot(node) {
-                  return node.closedShadowRoot;
-                },
-              }),
-              'tabbable with options should not find because slot container is hidden'
-            )
-          ).to.eql(expected);
-        });
-      });
+        }
+      );
     });
   });
 });

--- a/test/e2e/shadow-dom.cy.js
+++ b/test/e2e/shadow-dom.cy.js
@@ -166,450 +166,526 @@ describe('web-components', () => {
   });
 
   describe('tabbable/focusable', () => {
-    it('should find elements inside shadow dom', () => {
-      const expected = ['light-before', 'shadow-input', 'light-after'];
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'shadow-input',
-      });
+    [false, true].forEach((inertTest) => {
+      describe(`${inertTest ? 'inertness' : 'activeness'}`, () => {
+        it(`should${inertTest ? ' not' : ''} find${
+          inertTest ? ' inert' : ''
+        } elements inside shadow dom`, () => {
+          const expected = inertTest
+            ? ['light-before', 'light-after']
+            : ['light-before', 'shadow-input', 'light-after'];
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: inertTest ? 'inert-shadow-input' : 'shadow-input',
+          });
 
-      let result = tabbable(container, { getShadowRoot() {} });
-      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-        expected
-      );
+          let result = tabbable(container, { getShadowRoot() {} });
+          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+            expected
+          );
 
-      result = tabbable(container, { getShadowRoot: true });
-      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
-    });
+          result = tabbable(container, { getShadowRoot: true });
+          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+            expected
+          );
+        });
 
-    it('should find tabbable host', () => {
-      const expected = [
-        'light-before',
-        'tabbable-host',
-        'shadow-input',
-        'light-after',
-      ];
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'tabbable-host',
-      });
+        it(`should${inertTest ? ' not' : ''} find${
+          inertTest ? ' inert' : ''
+        } tabbable host`, () => {
+          const expected = inertTest
+            ? ['light-before', 'light-after']
+            : ['light-before', 'tabbable-host', 'shadow-input', 'light-after'];
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: inertTest ? 'inert-tabbable-host' : 'tabbable-host',
+          });
 
-      let result = tabbable(container, { getShadowRoot() {} });
-      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-        expected
-      );
+          let result = tabbable(container, { getShadowRoot() {} });
+          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+            expected
+          );
 
-      result = tabbable(container, { getShadowRoot: true });
-      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
-    });
+          result = tabbable(container, { getShadowRoot: true });
+          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+            expected
+          );
+        });
 
-    // make sure we're not conflicting with valid `scope` attribute on <th> elements
-    //  when we're sorting nodes in tab order (we don't test focusable() because
-    //  there's no focus order)
-    it('should find tabbable scoped headers', () => {
-      const expected = [
-        'header-athlete-col',
-        'header-swim-col',
-        'header-bike-col',
-        'header-run-col',
-      ];
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'table-with-tabbable-scoped-headers',
-      });
+        // make sure we're not conflicting with valid `scope` attribute on <th> elements
+        //  when we're sorting nodes in tab order (we don't test focusable() because
+        //  there's no focus order)
+        it(`should${inertTest ? ' not' : ''} find${
+          inertTest ? ' inert' : ''
+        } tabbable scoped headers`, () => {
+          const expected = inertTest
+            ? []
+            : [
+                'header-athlete-col',
+                'header-swim-col',
+                'header-bike-col',
+                'header-run-col',
+              ];
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: inertTest
+              ? 'table-with-inert-tabbable-scoped-headers'
+              : 'table-with-tabbable-scoped-headers',
+          });
 
-      const result = tabbable(container);
-      expect(getIdsFromElementsArray(result), 'tabbable').to.eql(expected);
-    });
+          const result = tabbable(container);
+          expect(getIdsFromElementsArray(result), 'tabbable').to.eql(expected);
+        });
 
-    it('should find elements inside shadow dom when directly querying the element with shadow root', () => {
-      const expected = ['shadow-input'];
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'shadow-input',
-      });
-      const shadowElement = container.querySelector('test-shadow');
+        it(`should${
+          inertTest ? ' not' : ''
+        } find elements inside shadow dom when directly querying the${
+          inertTest ? ' inert' : ''
+        } element with shadow root`, () => {
+          const expected = inertTest ? [] : ['shadow-input'];
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: 'shadow-input',
+          });
+          const shadowElement = container.querySelector('test-shadow');
+          shadowElement.inert = inertTest;
 
-      let result = tabbable(shadowElement, { getShadowRoot() {} });
-      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-        expected
-      );
+          let result = tabbable(shadowElement, { getShadowRoot() {} });
+          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+            expected
+          );
 
-      result = tabbable(shadowElement, { getShadowRoot: true });
-      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
-    });
+          result = tabbable(shadowElement, { getShadowRoot: true });
+          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+            expected
+          );
+        });
 
-    it('should find elements inside shadow dom when directly querying the element with shadow root (include container)', () => {
-      const expected = ['shadow-host', 'shadow-input'];
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'shadow-input',
-      });
-      const shadowElement = container.querySelector('test-shadow');
-      shadowElement.setAttribute('id', 'shadow-host');
-      shadowElement.setAttribute('tabindex', 0);
+        it(`should${
+          inertTest ? ' not' : ''
+        } find elements inside shadow dom when directly querying the${
+          inertTest ? ' inert' : ''
+        } element with shadow root (include container)`, () => {
+          const expected = inertTest ? [] : ['shadow-host', 'shadow-input'];
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: 'shadow-input',
+          });
+          const shadowElement = container.querySelector('test-shadow');
+          shadowElement.setAttribute('id', 'shadow-host');
+          shadowElement.setAttribute('tabindex', 0);
+          shadowElement.inert = inertTest;
 
-      let result = tabbable(shadowElement, {
-        getShadowRoot() {},
-        includeContainer: true,
-      });
-      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-        expected
-      );
+          let result = tabbable(shadowElement, {
+            getShadowRoot() {},
+            includeContainer: true,
+          });
+          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+            expected
+          );
 
-      result = tabbable(shadowElement, {
-        getShadowRoot: true,
-        includeContainer: true,
-      });
-      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
-    });
+          result = tabbable(shadowElement, {
+            getShadowRoot: true,
+            includeContainer: true,
+          });
+          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+            expected
+          );
+        });
 
-    it('should not find elements inside shadow dom that browsers will skip due to -1 tabindex on host', () => {
-      const expected = [];
-      const { container } = setupFixture(fixtures['shadow-dom-untabbable'], {
-        window,
-      });
-      const shadowElement = container.querySelector('test-shadow');
+        it('should not find elements inside shadow dom that browsers will skip due to -1 tabindex on host', () => {
+          const expected = [];
+          const { container } = setupFixture(
+            fixtures['shadow-dom-untabbable'],
+            {
+              window,
+            }
+          );
+          const shadowElement = container.querySelector('test-shadow');
 
-      let result = tabbable(shadowElement, { getShadowRoot() {} });
-      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-        expected
-      );
+          let result = tabbable(shadowElement, { getShadowRoot() {} });
+          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+            expected
+          );
 
-      result = tabbable(shadowElement, { getShadowRoot: true });
-      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
-    });
+          result = tabbable(shadowElement, { getShadowRoot: true });
+          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+            expected
+          );
+        });
 
-    it('should sort slots inside shadow dom', () => {
-      const expected = [
-        'light-before',
-        'light-slotter-before',
-        'shadow-input',
-        'light-slotter-after',
-        'light-slotter-default',
-        'default-slot-input',
-        'light-after',
-      ];
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'light-shadow-with-slots',
-      });
+        // NOTE: the inert attribute on a <slot> is either inherited by the slotted element,
+        //  or respected by the browser as an inert ancestor (either way, the slotted element
+        //  ends-up inert too)
+        it(`should${
+          inertTest ? ' ignore inert' : ' sort'
+        } slots inside shadow dom`, () => {
+          const expected = inertTest
+            ? ['light-before', 'shadow-input', 'light-after']
+            : [
+                'light-before',
+                'light-slotter-before',
+                'shadow-input',
+                'light-slotter-after',
+                'light-slotter-default',
+                'default-slot-input',
+                'light-after',
+              ];
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: inertTest
+              ? 'light-shadow-with-inert-slots'
+              : 'light-shadow-with-slots',
+          });
 
-      let result = tabbable(container, { getShadowRoot() {} });
-      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-        expected
-      );
+          let result = tabbable(container, { getShadowRoot() {} });
+          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+            expected
+          );
 
-      result = tabbable(container, { getShadowRoot: true });
-      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
-    });
+          result = tabbable(container, { getShadowRoot: true });
+          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+            expected
+          );
+        });
 
-    it('should sort shadow and light elements separately', () => {
-      const expected = [
-        'light-first',
-        'light-middle',
-        'light-last',
-        'shadow-first',
-        'shadow-middle',
-        'shadow-last',
-      ];
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'light-shadow-tab-index',
-      });
+        it('should sort shadow and light elements separately', () => {
+          const expected = [
+            'light-first',
+            'light-middle',
+            'light-last',
+            'shadow-first',
+            'shadow-middle',
+            'shadow-last',
+          ];
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: 'light-shadow-tab-index',
+          });
 
-      let result = tabbable(container, { getShadowRoot() {} });
-      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-        expected
-      );
+          let result = tabbable(container, { getShadowRoot() {} });
+          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+            expected
+          );
 
-      result = tabbable(container, { getShadowRoot() {} });
-      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
-    });
+          result = tabbable(container, { getShadowRoot() {} });
+          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+            expected
+          );
+        });
 
-    it('should sort slots content by slots tabindex', () => {
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'slots-tab-index',
-      });
+        it('should sort slots content by slots tabindex', () => {
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: 'slots-tab-index',
+          });
 
-      let tabbableList = tabbable(container, { getShadowRoot() {} });
-      let focusableList = focusable(container, { getShadowRoot() {} });
+          let tabbableList = tabbable(container, { getShadowRoot() {} });
+          let focusableList = focusable(container, { getShadowRoot() {} });
 
-      expect(
-        getIdsFromElementsArray(tabbableList),
-        'tabbable, using `() => {}`'
-      ).to.eql([
-        'light-1',
-        'shadow-1',
-        'shadow-2',
-        'light-2',
-        'shadow-3',
-        'light-3',
-      ]);
-      expect(
-        getIdsFromElementsArray(focusableList),
-        'focusable, using `() => {}`'
-      ).to.eql([
-        'shadow-3',
-        'light-3',
-        'light-2',
-        'light-1',
-        'shadow-2',
-        'shadow-1',
-      ]);
+          expect(
+            getIdsFromElementsArray(tabbableList),
+            'tabbable, using `() => {}`'
+          ).to.eql([
+            'light-1',
+            'shadow-1',
+            'shadow-2',
+            'light-2',
+            'shadow-3',
+            'light-3',
+          ]);
+          expect(
+            getIdsFromElementsArray(focusableList),
+            'focusable, using `() => {}`'
+          ).to.eql([
+            'shadow-3',
+            'light-3',
+            'light-2',
+            'light-1',
+            'shadow-2',
+            'shadow-1',
+          ]);
 
-      tabbableList = tabbable(container, { getShadowRoot: true });
-      focusableList = focusable(container, { getShadowRoot: true });
+          tabbableList = tabbable(container, { getShadowRoot: true });
+          focusableList = focusable(container, { getShadowRoot: true });
 
-      expect(
-        getIdsFromElementsArray(tabbableList),
-        'tabbable, using `true`'
-      ).to.eql([
-        'light-1',
-        'shadow-1',
-        'shadow-2',
-        'light-2',
-        'shadow-3',
-        'light-3',
-      ]);
-      expect(
-        getIdsFromElementsArray(focusableList),
-        'focusable, using `true`'
-      ).to.eql([
-        'shadow-3',
-        'light-3',
-        'light-2',
-        'light-1',
-        'shadow-2',
-        'shadow-1',
-      ]);
-    });
+          expect(
+            getIdsFromElementsArray(tabbableList),
+            'tabbable, using `true`'
+          ).to.eql([
+            'light-1',
+            'shadow-1',
+            'shadow-2',
+            'light-2',
+            'shadow-3',
+            'light-3',
+          ]);
+          expect(
+            getIdsFromElementsArray(focusableList),
+            'focusable, using `true`'
+          ).to.eql([
+            'shadow-3',
+            'light-3',
+            'light-2',
+            'light-1',
+            'shadow-2',
+            'shadow-1',
+          ]);
+        });
 
-    it('should insert slots nested content according to slot positions', () => {
-      const expected = [
-        'light-1',
-        'light-2',
-        'light-3',
-        'shadow-between',
-        'light-4',
-        'light-5',
-        'light-6',
-      ];
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'slots-nested-tab-index',
-      });
+        it('should insert slots nested content according to slot positions', () => {
+          const expected = [
+            'light-1',
+            'light-2',
+            'light-3',
+            'shadow-between',
+            'light-4',
+            'light-5',
+            'light-6',
+          ];
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: 'slots-nested-tab-index',
+          });
 
-      let result = tabbable(container, { getShadowRoot() {} });
-      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-        expected
-      );
+          let result = tabbable(container, { getShadowRoot() {} });
+          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+            expected
+          );
 
-      result = tabbable(container, { getShadowRoot: true });
-      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
-    });
+          result = tabbable(container, { getShadowRoot: true });
+          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+            expected
+          );
+        });
 
-    it('should query nested shadow doms for slots', () => {
-      const expected = [
-        'shadow-outter-before',
-        'shadow-inner',
-        'light-slotted-input',
-        'shadow-outter-after',
-      ];
+        it(`should query nested shadow doms for slots${
+          inertTest ? ' (inert test)' : ''
+        }`, () => {
+          const expected = inertTest
+            ? ['shadow-outter-before', 'shadow-inner', 'shadow-outter-after']
+            : [
+                'shadow-outter-before',
+                'shadow-inner',
+                'light-slotted-input',
+                'shadow-outter-after',
+              ];
 
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'slotted-through-multiple-shadows',
-      });
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: inertTest
+              ? 'inert-slotted-through-multiple-shadows'
+              : 'slotted-through-multiple-shadows',
+          });
 
-      let result = tabbable(container, { getShadowRoot() {} });
-      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-        expected
-      );
+          let result = tabbable(container, { getShadowRoot() {} });
+          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+            expected
+          );
 
-      result = tabbable(container, { getShadowRoot: true });
-      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
-    });
+          result = tabbable(container, { getShadowRoot: true });
+          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+            expected
+          );
+        });
 
-    it('should find elements inside slot', () => {
-      const expected = ['light-slotter-before'];
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'light-shadow-with-slots',
-      });
-      const shadowElement = container.querySelector('test-shadow');
-      const slot = shadowElement.shadowRoot.querySelector(
-        'slot[name="before"]'
-      );
+        it(`should${inertTest ? ' not' : ''} find elements inside${
+          inertTest ? ' inert' : ''
+        } slot`, () => {
+          const expected = inertTest ? [] : ['light-slotter-before'];
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: inertTest
+              ? 'light-shadow-with-inert-slots'
+              : 'light-shadow-with-slots',
+          });
+          const shadowElement = container.querySelector('test-shadow');
+          const slot = shadowElement.shadowRoot.querySelector(
+            'slot[name="before"]'
+          );
 
-      let result = tabbable(slot, { getShadowRoot() {} });
-      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-        expected
-      );
+          let result = tabbable(slot, { getShadowRoot() {} });
+          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+            expected
+          );
 
-      result = tabbable(slot, { getShadowRoot: true });
-      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
-    });
+          result = tabbable(slot, { getShadowRoot: true });
+          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+            expected
+          );
+        });
 
-    it('should not find slot with tabindex', () => {
-      const expected = ['light-slotter-before'];
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'light-shadow-with-slots',
-      });
-      const shadowElement = container.querySelector('test-shadow');
-      const slot = shadowElement.shadowRoot.querySelector(
-        'slot[name="before"]'
-      );
-      slot.id = 'slot-id';
-      slot.tabIndex = '1';
+        // (i.e. slot with tabindex should be ignored; only slotted element should be found)
+        it('should not find slot with tabindex', () => {
+          const expected = ['light-slotter-before'];
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: 'light-shadow-with-slots',
+          });
+          const shadowElement = container.querySelector('test-shadow');
+          const slot = shadowElement.shadowRoot.querySelector(
+            'slot[name="before"]'
+          );
+          slot.id = 'slot-id';
+          slot.tabIndex = '1';
 
-      let result = tabbable(slot, { getShadowRoot() {} });
-      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-        expected
-      );
+          let result = tabbable(slot, { getShadowRoot() {} });
+          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+            expected
+          );
 
-      result = tabbable(slot, { getShadowRoot: true });
-      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
-    });
+          result = tabbable(slot, { getShadowRoot: true });
+          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+            expected
+          );
+        });
 
-    it('should filter un-tabbable elements', () => {
-      const expected = [
-        'shadow-summary',
-        'shadow-details-without-summary',
-        'shadow-radio-checked',
-      ];
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'filter-conditions',
-      });
+        it('should filter un-tabbable elements', () => {
+          const expected = [
+            'shadow-summary',
+            'shadow-details-without-summary',
+            'shadow-radio-checked',
+          ];
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: 'filter-conditions',
+          });
 
-      let result = tabbable(container, { getShadowRoot() {} });
-      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-        expected
-      );
+          let result = tabbable(container, { getShadowRoot() {} });
+          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+            expected
+          );
 
-      result = tabbable(container, { getShadowRoot: true });
-      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
-    });
+          result = tabbable(container, { getShadowRoot: true });
+          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+            expected
+          );
+        });
 
-    it('should filter un-focusable elements', () => {
-      const expected = [
-        'shadow-summary',
-        'shadow-details-without-summary',
-        'shadow-radio-unchecked',
-        'shadow-radio-checked',
-        'shadow-negative-tabindex',
-      ];
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'filter-conditions',
-      });
+        it('should filter un-focusable elements', () => {
+          const expected = [
+            'shadow-summary',
+            'shadow-details-without-summary',
+            'shadow-radio-unchecked',
+            'shadow-radio-checked',
+            'shadow-negative-tabindex',
+          ];
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: 'filter-conditions',
+          });
 
-      let result = focusable(container, { getShadowRoot() {} });
-      expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
-        expected
-      );
+          let result = focusable(container, { getShadowRoot() {} });
+          expect(getIdsFromElementsArray(result), 'using `() => {}`').to.eql(
+            expected
+          );
 
-      result = focusable(container, { getShadowRoot: true });
-      expect(getIdsFromElementsArray(result), 'using `true`').to.eql(expected);
-    });
+          result = focusable(container, { getShadowRoot: true });
+          expect(getIdsFromElementsArray(result), 'using `true`').to.eql(
+            expected
+          );
+        });
 
-    it('should accept shadow root in order to query closed shadows', () => {
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'closed-shadow-input',
-      });
+        it(`should accept shadow root in order to query closed shadows${
+          inertTest ? ' (inert test)' : ''
+        }`, () => {
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: inertTest
+              ? 'closed-inert-shadow-input'
+              : 'closed-shadow-input',
+          });
 
-      const providedShadowRoot = tabbable(container, {
-        getShadowRoot(node) {
-          return node.closedShadowRoot;
-        },
-      });
-      const noKnowlegeOfShadowRootFn = tabbable(container, {
-        getShadowRoot(_node) {
-          return false;
-        },
-      });
-      const noKnowlegeOfShadowRootTrue = tabbable(container, {
-        getShadowRoot: true,
-      });
-      const undisclosedShadowRoot = tabbable(container, {
-        getShadowRoot(_node) {
-          return true;
-        },
-      });
-
-      expect(
-        getIdsFromElementsArray(providedShadowRoot),
-        'provided shadow root'
-      ).to.eql([
-        'light-before',
-        'shadow-input',
-        'light-slotted',
-        'light-after',
-      ]);
-      expect(
-        getIdsFromElementsArray(noKnowlegeOfShadowRootFn),
-        'no knowledge of shadow root, using `() => false`'
-      ).to.eql(['light-slotted', 'light-before', 'light-after']);
-      expect(
-        getIdsFromElementsArray(noKnowlegeOfShadowRootTrue),
-        'no knowledge of shadow root, using `true`'
-      ).to.eql(getIdsFromElementsArray(noKnowlegeOfShadowRootFn));
-      expect(
-        getIdsFromElementsArray(undisclosedShadowRoot),
-        'undisclosed shadow root'
-      ).to.eql(['light-before', 'light-slotted', 'light-after']);
-    });
-
-    // NOTE: this test shows that tabbable() and focusable() will not find
-    //  query-light-input-slotted whether we give the closed shadow root to look at
-    //  or not, because it's slotted into a 'display: none' container inside
-    //  the close shadow dom
-    it('should not match elements in a non display slot', () => {
-      const expected = [];
-      const { container } = setupFixture(fixtures.shadowDomQuery, {
-        window,
-        caseId: 'query-slot-display-none-closed-shadow',
-      });
-
-      expect(
-        getIdsFromElementsArray(
-          focusable(container),
-          'focusable no options (shadow support disabled) should not find'
-        )
-      ).to.eql(expected);
-
-      expect(
-        getIdsFromElementsArray(
-          focusable(container, {
+          const providedShadowRoot = tabbable(container, {
             getShadowRoot(node) {
               return node.closedShadowRoot;
             },
-          }),
-          'focusable with options should not find because slot container is hidden'
-        )
-      ).to.eql(expected);
-
-      expect(
-        getIdsFromElementsArray(
-          tabbable(container),
-          'tabbable no options (shadow support disabled) should not find'
-        )
-      ).to.eql(expected);
-
-      expect(
-        getIdsFromElementsArray(
-          tabbable(container, {
-            getShadowRoot(node) {
-              return node.closedShadowRoot;
+          });
+          const noKnowlegeOfShadowRootFn = tabbable(container, {
+            getShadowRoot(_node) {
+              return false;
             },
-          }),
-          'tabbable with options should not find because slot container is hidden'
-        )
-      ).to.eql(expected);
+          });
+          const noKnowlegeOfShadowRootTrue = tabbable(container, {
+            getShadowRoot: true,
+          });
+          const undisclosedShadowRoot = tabbable(container, {
+            getShadowRoot(_node) {
+              return true;
+            },
+          });
+
+          expect(
+            getIdsFromElementsArray(providedShadowRoot),
+            'provided shadow root'
+          ).to.eql([
+            'light-before',
+            ...(inertTest ? [] : ['shadow-input']),
+            'light-slotted',
+            'light-after',
+          ]);
+          expect(
+            getIdsFromElementsArray(noKnowlegeOfShadowRootFn),
+            'no knowledge of shadow root, using `() => false`'
+          ).to.eql(['light-slotted', 'light-before', 'light-after']);
+          expect(
+            getIdsFromElementsArray(noKnowlegeOfShadowRootTrue),
+            'no knowledge of shadow root, using `true`'
+          ).to.eql(getIdsFromElementsArray(noKnowlegeOfShadowRootFn));
+          expect(
+            getIdsFromElementsArray(undisclosedShadowRoot),
+            'undisclosed shadow root'
+          ).to.eql(['light-before', 'light-slotted', 'light-after']);
+        });
+
+        // NOTE: this test shows that tabbable() and focusable() will not find
+        //  query-light-input-slotted whether we give the closed shadow root to look at
+        //  or not, because it's slotted into a 'display: none' container inside
+        //  the close shadow dom
+        it('should not match elements in a non display slot', () => {
+          const expected = [];
+          const { container } = setupFixture(fixtures.shadowDomQuery, {
+            window,
+            caseId: 'query-slot-display-none-closed-shadow',
+          });
+
+          expect(
+            getIdsFromElementsArray(
+              focusable(container),
+              'focusable no options (shadow support disabled) should not find'
+            )
+          ).to.eql(expected);
+
+          expect(
+            getIdsFromElementsArray(
+              focusable(container, {
+                getShadowRoot(node) {
+                  return node.closedShadowRoot;
+                },
+              }),
+              'focusable with options should not find because slot container is hidden'
+            )
+          ).to.eql(expected);
+
+          expect(
+            getIdsFromElementsArray(
+              tabbable(container),
+              'tabbable no options (shadow support disabled) should not find'
+            )
+          ).to.eql(expected);
+
+          expect(
+            getIdsFromElementsArray(
+              tabbable(container, {
+                getShadowRoot(node) {
+                  return node.closedShadowRoot;
+                },
+              }),
+              'tabbable with options should not find because slot container is hidden'
+            )
+          ).to.eql(expected);
+        });
+      });
     });
   });
 });

--- a/test/e2e/shadow-dom.cy.js
+++ b/test/e2e/shadow-dom.cy.js
@@ -320,7 +320,8 @@ describe('web-components', () => {
         );
       });
 
-      it('should filter un-tabbable elements', () => {
+      // TODO[ff-inert-support]: FF does not yet (Feb 2023) support the `inert` attribute
+      it('should filter un-tabbable elements', { browser: '!firefox' }, () => {
         const expected = [
           'shadow-summary',
           'shadow-details-without-summary',
@@ -342,7 +343,8 @@ describe('web-components', () => {
         );
       });
 
-      it('should filter un-focusable elements', () => {
+      // TODO[ff-inert-support]: FF does not yet (Feb 2023) support the `inert` attribute
+      it('should filter un-focusable elements', { browser: '!firefox' }, () => {
         const expected = [
           'shadow-summary',
           'shadow-details-without-summary',

--- a/test/e2e/tabbable.cy.js
+++ b/test/e2e/tabbable.cy.js
@@ -104,75 +104,80 @@ describe('tabbable', () => {
       });
     });
 
-    [undefined, 'full', 'legacy-full', 'non-zero-area', 'none'].forEach(
-      (displayCheck) => {
-        it(`correctly identifies tabbable elements in the "inert" example with displayCheck=${
-          displayCheck || '<default>'
-        }`, () => {
-          const container = document.createElement('div');
-          container.innerHTML = fixtures.inert;
-          document.body.append(container);
+    // TODO[ff-inert-support]: FF does not yet (Feb 2023) support the `inert` attribute
+    describe('inertness', { browser: '!firefox' }, () => {
+      [undefined, 'full', 'legacy-full', 'non-zero-area', 'none'].forEach(
+        (displayCheck) => {
+          it(`correctly identifies tabbable elements in the "inert" example with displayCheck=${
+            displayCheck || '<default>'
+          }`, () => {
+            const container = document.createElement('div');
+            container.innerHTML = fixtures.inert;
+            document.body.append(container);
 
-          // non-inert container, but every element inside of it is
-          const tabbableElements = tabbable(container, { displayCheck });
+            // non-inert container, but every element inside of it is
+            const tabbableElements = tabbable(container, { displayCheck });
 
-          expect(getIdsFromElementsArray(tabbableElements)).to.eql([]);
-        });
-
-        it(`correctly identifies tabbable elements in the "basic" example with displayCheck=${
-          displayCheck || '<default>'
-        } when placed directly inside an inert container`, () => {
-          const container = document.createElement('div');
-          container.innerHTML = fixtures.basic;
-          container.inert = true;
-          document.body.append(container);
-
-          // inert container has non-inert children
-          const tabbableElements = tabbable(container, { displayCheck });
-
-          expect(getIdsFromElementsArray(tabbableElements)).to.eql([]);
-        });
-
-        it(`correctly identifies tabbable elements in the "basic" example with displayCheck=${
-          displayCheck || '<default>'
-        } when nested inside an inert container`, () => {
-          const container = document.createElement('div');
-          container.innerHTML = fixtures.basic;
-          container.inert = true;
-
-          const parentContainer = document.createElement('div');
-          parentContainer.appendChild(container);
-          document.body.append(parentContainer);
-
-          // non-inert parent has inert container which has non-inert children
-          const tabbableElements = tabbable(parentContainer, { displayCheck });
-
-          expect(getIdsFromElementsArray(tabbableElements)).to.eql([]);
-        });
-
-        it(`correctly identifies tabbable elements in the "basic" example with displayCheck=${
-          displayCheck || '<default>'
-        } when deeply nested inside an inert container`, () => {
-          const container = document.createElement('div');
-          container.innerHTML = fixtures.basic;
-
-          const parentContainer = document.createElement('div');
-          parentContainer.inert = true;
-          parentContainer.appendChild(container);
-
-          const grandparentContainer = document.createElement('div');
-          grandparentContainer.appendChild(parentContainer);
-          document.body.append(grandparentContainer);
-
-          // non-inert grandparent has inert parent, which has non-container with children
-          const tabbableElements = tabbable(grandparentContainer, {
-            displayCheck,
+            expect(getIdsFromElementsArray(tabbableElements)).to.eql([]);
           });
 
-          expect(getIdsFromElementsArray(tabbableElements)).to.eql([]);
-        });
-      }
-    );
+          it(`correctly identifies tabbable elements in the "basic" example with displayCheck=${
+            displayCheck || '<default>'
+          } when placed directly inside an inert container`, () => {
+            const container = document.createElement('div');
+            container.innerHTML = fixtures.basic;
+            container.inert = true;
+            document.body.append(container);
+
+            // inert container has non-inert children
+            const tabbableElements = tabbable(container, { displayCheck });
+
+            expect(getIdsFromElementsArray(tabbableElements)).to.eql([]);
+          });
+
+          it(`correctly identifies tabbable elements in the "basic" example with displayCheck=${
+            displayCheck || '<default>'
+          } when nested inside an inert container`, () => {
+            const container = document.createElement('div');
+            container.innerHTML = fixtures.basic;
+            container.inert = true;
+
+            const parentContainer = document.createElement('div');
+            parentContainer.appendChild(container);
+            document.body.append(parentContainer);
+
+            // non-inert parent has inert container which has non-inert children
+            const tabbableElements = tabbable(parentContainer, {
+              displayCheck,
+            });
+
+            expect(getIdsFromElementsArray(tabbableElements)).to.eql([]);
+          });
+
+          it(`correctly identifies tabbable elements in the "basic" example with displayCheck=${
+            displayCheck || '<default>'
+          } when deeply nested inside an inert container`, () => {
+            const container = document.createElement('div');
+            container.innerHTML = fixtures.basic;
+
+            const parentContainer = document.createElement('div');
+            parentContainer.inert = true;
+            parentContainer.appendChild(container);
+
+            const grandparentContainer = document.createElement('div');
+            grandparentContainer.appendChild(parentContainer);
+            document.body.append(grandparentContainer);
+
+            // non-inert grandparent has inert parent, which has non-container with children
+            const tabbableElements = tabbable(grandparentContainer, {
+              displayCheck,
+            });
+
+            expect(getIdsFromElementsArray(tabbableElements)).to.eql([]);
+          });
+        }
+      );
+    });
 
     it('correctly identifies tabbable elements in the "nested" example', () => {
       const expectedTabbableIds = ['tabindex-div-2', 'tabindex-div-0', 'input'];

--- a/test/e2e/tabbable.cy.js
+++ b/test/e2e/tabbable.cy.js
@@ -104,6 +104,76 @@ describe('tabbable', () => {
       });
     });
 
+    [undefined, 'full', 'legacy-full', 'non-zero-area', 'none'].forEach(
+      (displayCheck) => {
+        it(`correctly identifies tabbable elements in the "inert" example with displayCheck=${
+          displayCheck || '<default>'
+        }`, () => {
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.inert;
+          document.body.append(container);
+
+          // non-inert container, but every element inside of it is
+          const tabbableElements = tabbable(container, { displayCheck });
+
+          expect(getIdsFromElementsArray(tabbableElements)).to.eql([]);
+        });
+
+        it(`correctly identifies tabbable elements in the "basic" example with displayCheck=${
+          displayCheck || '<default>'
+        } when placed directly inside an inert container`, () => {
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.basic;
+          container.inert = true;
+          document.body.append(container);
+
+          // inert container has non-inert children
+          const tabbableElements = tabbable(container, { displayCheck });
+
+          expect(getIdsFromElementsArray(tabbableElements)).to.eql([]);
+        });
+
+        it(`correctly identifies tabbable elements in the "basic" example with displayCheck=${
+          displayCheck || '<default>'
+        } when nested inside an inert container`, () => {
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.basic;
+          container.inert = true;
+
+          const parentContainer = document.createElement('div');
+          parentContainer.appendChild(container);
+          document.body.append(parentContainer);
+
+          // non-inert parent has inert container which has non-inert children
+          const tabbableElements = tabbable(parentContainer, { displayCheck });
+
+          expect(getIdsFromElementsArray(tabbableElements)).to.eql([]);
+        });
+
+        it(`correctly identifies tabbable elements in the "basic" example with displayCheck=${
+          displayCheck || '<default>'
+        } when deeply nested inside an inert container`, () => {
+          const container = document.createElement('div');
+          container.innerHTML = fixtures.basic;
+
+          const parentContainer = document.createElement('div');
+          parentContainer.inert = true;
+          parentContainer.appendChild(container);
+
+          const grandparentContainer = document.createElement('div');
+          grandparentContainer.appendChild(parentContainer);
+          document.body.append(grandparentContainer);
+
+          // non-inert grandparent has inert parent, which has non-container with children
+          const tabbableElements = tabbable(grandparentContainer, {
+            displayCheck,
+          });
+
+          expect(getIdsFromElementsArray(tabbableElements)).to.eql([]);
+        });
+      }
+    );
+
     it('correctly identifies tabbable elements in the "nested" example', () => {
       const expectedTabbableIds = ['tabindex-div-2', 'tabindex-div-0', 'input'];
 

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 
 module.exports = {
   basic: fs.readFileSync(path.join(__dirname, 'basic.html'), 'utf8'),
+  inert: fs.readFileSync(path.join(__dirname, 'inert.html'), 'utf8'),
   'changing-content': fs.readFileSync(
     path.join(__dirname, 'changing-content.html'),
     'utf8'

--- a/test/fixtures/inert.html
+++ b/test/fixtures/inert.html
@@ -1,0 +1,79 @@
+<div inert id="contenteditable-true" contenteditable="true" style="padding:1em">
+  editable text
+</div>
+<div inert id="contenteditable-false" contenteditable="false" style="padding:1em">
+  not editable text
+</div>
+<div inert id="contenteditable-nesting" contenteditable style="padding:1em">
+  <div>
+    <div>
+      editable text
+    </div>
+  </div>
+</div>
+<div inert id="contenteditable-negative-tabindex" contenteditable="true" tabindex="-1" style="padding:1em">
+  this editable text is focusable but not tabbable
+</div>
+<div inert id="contenteditable-NaN-tabindex" contenteditable="true" tabindex="NaN" style="padding:1em">
+  editable text
+</div>
+
+<input inert id="input" type="text" />
+<input inert id="input-readonly" readonly />
+<select inert id="select">
+  <option value="foo">foo</option>
+</select>
+<select inert id="select-readonly" readyonly>
+  <option value="foo">foo</option>
+</select>
+<a inert id="href-anchor" href="#">foo</a>
+<a inert id="tabindex-hrefless-anchor" tabindex="1">foo</a>
+<textarea inert id="textarea" cols="30" rows="10"></textarea>
+<textarea inert id="textarea-readonly" readyonly cols="30" rows="10"></textarea>
+<button inert id="button">foo</button>
+<div inert id="tabindex-div" tabindex="0">foo</div>
+
+<input inert id="disabled-input" type="text" disabled />
+<input inert id="hidden-input" type="hidden" />
+<select inert id="negative-select" tabindex="-1">
+  <option value="foo">foo</option>
+</select>
+<a inert id="hrefless-anchor">foo</a>
+<textarea
+  inert
+  id="displaynone-textarea"
+  cols="30"
+  rows="10"
+  style="display:none;"
+></textarea>
+<button inert id="visibilityhidden-button" style="visibility:hidden;">foo</button>
+<div inert style="visibility:hidden;">
+  <button inert id="hiddenParent-button">foo</button>
+  <button inert id="hiddenParentVisible-button" style="visibility:visible;">
+    bar
+  </button>
+</div>
+<div inert id="noindex-div">foo</div>
+
+<div inert id="displaycontents" style="display: contents; background-color: lime;" tabindex="0">
+  <div inert id="displaycontents-child" tabindex="0">displaycontents-child</div>
+  <div inert id="displaycontents-child-displaynone" style="display: none" tabindex="0">displaycontents-child-displaynone</div>
+</div>
+
+<audio inert id="audio-control" controls></audio>
+<audio inert id="audio-nocontrol"></audio>
+<audio inert id="audio-control-NaN-tabindex" tabindex="foo" controls></audio>
+
+<video inert id="video-control" controls></video>
+<video inert id="video-nocontrol"></video>
+<video inert id="video-control-NaN-tabindex" tabindex="bar" controls></video>
+
+<iframe
+  inert
+  id="iframe"
+  src="https://en.wikipedia.org/wiki/Mars_Reconnaissance_Orbiter"
+></iframe>
+
+<div inert id="inert-parent-div">
+  <button id="inert-parent-button">foo</button>
+</div>

--- a/test/fixtures/shadow-dom-query.html
+++ b/test/fixtures/shadow-dom-query.html
@@ -11,10 +11,36 @@
     <input id="light-after"></input>
 </div>
 
+<div id="inert-shadow-input">
+    <h2>inert shadow input</h2>
+    <input id="light-before"></input>
+    <test-shadow>
+        <template shadowroot="open">
+            <div>
+                <input inert id="inert-shadow-input"></input>
+            </div>
+        </template>
+    </test-shadow>
+    <input id="light-after"></input>
+</div>
+
 <div id="tabbable-host">
     <h2>tabbable host</h2>
     <input id="light-before"></input>
     <test-shadow tabindex="0" id="tabbable-host">
+        <template shadowroot="open">
+            <div>
+                <input id="shadow-input"></input>
+            </div>
+        </template>
+    </test-shadow>
+    <input id="light-after"></input>
+</div>
+
+<div id="inert-tabbable-host">
+    <h2>inert tabbable host</h2>
+    <input id="light-before"></input>
+    <test-shadow inert tabindex="0" id="inert-tabbable-host">
         <template shadowroot="open">
             <div>
                 <input id="shadow-input"></input>
@@ -37,6 +63,30 @@
                     <input id="default-slot-input-overridden"></input>
                 </slot>
                 <slot name="default-content">
+                    <input id="default-slot-input"></input>
+                </slot>
+            </div>
+        </template>
+        <input id="light-slotter-before" slot="before"></input>
+        <input id="light-slotter-after" slot="after"></input>
+        <input id="light-slotter-default"></input>
+    </test-shadow>
+    <input id="light-after"></input>
+</div>
+
+<div id="light-shadow-with-inert-slots">
+    <h2>light shadow and inert slots</h2>
+    <input id="light-before"></input>
+    <test-shadow>
+        <template shadowroot="open">
+            <div>
+                <slot inert name="before"></slot>
+                <input id="shadow-input"></input>
+                <slot inert name="after"></slot>
+                <slot inert>
+                    <input id="default-slot-input-overridden"></input>
+                </slot>
+                <slot inert name="default-content">
                     <input id="default-slot-input"></input>
                 </slot>
             </div>
@@ -99,7 +149,7 @@
 </div>
 
 <div id="slotted-through-multiple-shadows">
-    <h2>slot through multiple nested shadow roots</h2>
+    <h2>slotted through multiple nested shadow roots</h2>
     <test-shadow>
         <template shadowroot="open">
             <input id="shadow-outter-before"></input>
@@ -109,6 +159,24 @@
                     <slot></slot>
                 </template>
                 <slot></slot>
+            </test-shadow>
+            <input id="shadow-outter-after"></input>
+        </template>
+        <input id="light-slotted-input"></input>
+    </test-shadow>
+</div>
+
+<div id="inert-slotted-through-multiple-shadows">
+    <h2>inert slotted through multiple nested shadow roots</h2>
+    <test-shadow>
+        <template shadowroot="open">
+            <input id="shadow-outter-before"></input>
+            <test-shadow>
+                <template shadowroot="open">
+                    <input id="shadow-inner"></input>
+                    <slot inert></slot>
+                </template>
+                <slot inert></slot>
             </test-shadow>
             <input id="shadow-outter-after"></input>
         </template>
@@ -132,6 +200,7 @@
             <input id="shadow-radio-unchecked" type="radio" name="group-a"></input>
             <input id="shadow-radio-checked" type="radio" name="group-a" checked></input>
             <input id="shadow-negative-tabindex" tabindex="-1"></input>
+            <input id="shadow-inert" inert></input>
         </template>
     </test-shadow>
 </div>
@@ -143,6 +212,21 @@
         <template shadowroot="closed">
             <div>
                 <input id="shadow-input"></input>
+                <slot></slot>
+            </div>
+        </template>
+        <input id="light-slotted" tabindex="1"></input>
+    </test-shadow>
+    <input id="light-after"></input>
+</div>
+
+<div id="closed-inert-shadow-input">
+    <h2>closed inert shadow input</h2>
+    <input id="light-before"></input>
+    <test-shadow>
+        <template shadowroot="closed">
+            <div>
+                <input inert id="inert-shadow-input"></input>
                 <slot></slot>
             </div>
         </template>
@@ -171,6 +255,36 @@
             <th scope="col" tabindex="0" id="header-swim-col">Swim</th>
             <th scope="col" tabindex="0" id="header-bike-col">Bike</th>
             <th scope="col" tabindex="0" id="header-run-col">Run</th>
+        </tr>
+        <tr>
+            <th scope="row" id="header-athlete-row">John</th>
+            <td>7</td>
+            <td>12</td>
+            <td>10</td>
+        </tr>
+        <tr>
+            <th scope="row">Lisa</th>
+            <td>3</td>
+            <td>15</td>
+            <td>9</td>
+        </tr>
+        <tr>
+            <th scope="row">Paul</th>
+            <td>9</td>
+            <td>8</td>
+            <td>12</td>
+        </tr>
+    </table>
+</div>
+
+<div id="table-with-inert-tabbable-scoped-headers">
+    <h2>table with inert tabbable scoped headers</h2>
+    <table>
+        <tr>
+            <th scope="col" inert tabindex="0" id="header-athlete-col">Athlete</th>
+            <th scope="col" inert tabindex="0" id="header-swim-col">Swim</th>
+            <th scope="col" inert tabindex="0" id="header-bike-col">Bike</th>
+            <th scope="col" inert tabindex="0" id="header-run-col">Run</th>
         </tr>
         <tr>
             <th scope="row" id="header-athlete-row">John</th>


### PR DESCRIPTION
Fixes #292

Inert elements, as well as elements inside inert ancestors, will no longer be treated as tabbable/focusable.

Considering this a minor update since inert elements in browsers supporting the inert attribute (which has wide enough support now) would already be non-interactive. So this is tabbable catching to reality rather than tabbable altering behavior.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
