### PR TITLE
[#982] Pin nwsapi downstream jsdom dependency to v2.2.2

### DIFF
--- a/.changeset/short-readers-suffer.md
+++ b/.changeset/short-readers-suffer.md
@@ -1,0 +1,5 @@
+---
+'tabbable': patch
+---
+
+Pin jsdom downstream dependency nwsapi to v2.2.2 while awaiting fix ([#982](https://github.com/focus-trap/tabbable/issues/982))

--- a/package.json
+++ b/package.json
@@ -91,5 +91,8 @@
     "typescript": "^5.0.4",
     "watchify": "^4.0.0",
     "webpack": "^5.81.0"
+  },
+  "overrides": {
+    "nwsapi": "2.2.2"
   }
 }


### PR DESCRIPTION
Fixes #982

Tested locally by cloning this repo and then:
```
$ rm package-lock.json
$ npm install # regenerates package-lock.json
$ npm test # fails because of nwsapi issues post-v2.2.2
# edit package.json to add override clause
$ npm install # results in nwsapi@2.2.2
$ npm test # succeeds
```

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
