### PR TITLE
Make tabbable work with an array of elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -579,19 +579,33 @@ const sortByOrder = function (candidates) {
 const tabbable = function (el, options) {
   options = options || {};
 
+  const containers = Array.isArray(el) ? el : [el];
+
   let candidates;
   if (options.getShadowRoot) {
-    candidates = getCandidatesIteratively([el], options.includeContainer, {
-      filter: isNodeMatchingSelectorTabbable.bind(null, options),
-      flatten: false,
-      getShadowRoot: options.getShadowRoot,
-      shadowRootFilter: isValidShadowRootTabbable,
-    });
+    candidates = containers.reduce(
+      (prev, curr) =>
+        prev.concat(
+          getCandidatesIteratively([curr], options.includeContainer, {
+            filter: isNodeMatchingSelectorTabbable.bind(null, options),
+            flatten: false,
+            getShadowRoot: options.getShadowRoot,
+            shadowRootFilter: isValidShadowRootTabbable,
+          })
+        ),
+      []
+    );
   } else {
-    candidates = getCandidates(
-      el,
-      options.includeContainer,
-      isNodeMatchingSelectorTabbable.bind(null, options)
+    candidates = containers.reduce(
+      (prev, curr) =>
+        prev.concat(
+          getCandidates(
+            curr,
+            options.includeContainer,
+            isNodeMatchingSelectorTabbable.bind(null, options)
+          )
+        ),
+      []
     );
   }
   return sortByOrder(candidates);


### PR DESCRIPTION
Per discussions in https://github.com/focus-trap/focus-trap/issues/375 and work in https://github.com/focus-trap/focus-trap/pull/974, we need to:

- [x] Make `tabbable()` work with multiple containers
- [ ] Make `focusable()` work with multiple containers (for API symmetry)
- [ ] Expose `getTabIndex()` API so that focus-trap can use the same fallbacks as tabbable

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
