### PR TITLE
Sort `containers` before querying candidates within them

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -603,10 +603,12 @@ const sortByOrder = function (candidates) {
     .concat(regularTabbables);
 };
 
+const byDocumentOrder = (a, b) => (a.compareDocumentPosition(b) & 4 ? -1 : 1);
+
 const tabbable = function (el, options) {
   options = options || {};
 
-  const containers = Array.isArray(el) ? el : [el];
+  const containers = (Array.isArray(el) ? [...el] : [el]).sort(byDocumentOrder);
 
   let candidates;
   if (options.getShadowRoot) {
@@ -642,7 +644,7 @@ const tabbable = function (el, options) {
 const focusable = function (el, options) {
   options = options || {};
 
-  const containers = Array.isArray(el) ? el : [el];
+  const containers = (Array.isArray(el) ? [...el] : [el]).sort(byDocumentOrder);
 
   let candidates;
   if (options.getShadowRoot) {

--- a/src/index.js
+++ b/src/index.js
@@ -603,7 +603,7 @@ const sortByOrder = function (candidates) {
     .concat(regularTabbables);
 };
 
-const byDocumentOrder = (a, b) => (a.compareDocumentPosition(b) & 4 ? -1 : 1);
+const byDocumentOrder = (a, b) => (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1);
 
 const tabbable = function (el, options) {
   options = options || {};


### PR DESCRIPTION
<!--
Thank you for your contribution! 🎉

Please be sure to go over the PR CHECKLIST below before posting your PR to make sure we all think of "everything". :)
-->

If the elements passed to `tabbable` are not ordered (by document order) the resulting order of tabbable elements would be incorrect because [sortByOrder](https://github.com/focus-trap/tabbable/blob/a5f9369d1ef93f394a7f8d64e93ceebb4d8a70f0/src/index.js#L545) only sorts the candidates by tab index.


The `.documentOrder` here: 
https://github.com/focus-trap/tabbable/blob/a5f9369d1ef93f394a7f8d64e93ceebb4d8a70f0/src/index.js#L241

Is merely the index of an element within the array of candidates: https://github.com/focus-trap/tabbable/blob/a5f9369d1ef93f394a7f8d64e93ceebb4d8a70f0/src/index.js#L559

Which is also a true indication of the relative document orders when the candidates are queried from a single element or from multiple elements sorted by document order.

I presume the reason for that index is that `Array.prototype.sort()` is [stable only from ECMAScript 2019](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#sort_stability), it could be renamed to avoid confusion, but I'll leave that up to you.


<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
