### PR TITLE
Add new getTabIndex() export

### DIFF
--- a/.changeset/lovely-seals-burn.md
+++ b/.changeset/lovely-seals-burn.md
@@ -1,0 +1,5 @@
+---
+'tabbable': minor
+---
+
+Add new `getTabIndex()` API which enables Focus-trap to determine tab indexes in the same way as Tabbable when necessary (see [focus-trap#974](https://github.com/focus-trap/focus-trap/pull/974)).

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,11 +20,15 @@ export declare function focusable(
 ): FocusableElement[];
 
 export declare function isTabbable(
-  element: Element,
+  node: Element,
   options?: CheckOptions
 ): boolean;
 
 export declare function isFocusable(
-  element: Element,
+  node: Element,
   options?: CheckOptions
 ): boolean;
+
+export declare function getTabIndex(
+  node: Element,
+): number;

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -41,4 +41,5 @@ module.exports = {
     path.join(__dirname, 'shadow-dom-untabbable.html'),
     'utf8'
   ),
+  tabindex: fs.readFileSync(path.join(__dirname, 'tabindex.html'), 'utf8'),
 };

--- a/test/fixtures/tabindex.html
+++ b/test/fixtures/tabindex.html
@@ -1,0 +1,28 @@
+<a id="anchor-tabindex-none" href="#">no tabindex</a>
+<button id="btn-tabindex-1" tabindex="1">tabindex=1</button>
+
+<div id="contenteditable-tabindex-none" contenteditable="true" style="padding:1em">
+  editable text, no tabindex
+</div>
+<div id="contenteditable-tabindex-neg" contenteditable="true" style="padding:1em" tabindex="-1">
+  editable text, neg tabindex
+</div>
+
+<audio id="audio-control-tabindex-none" controls></audio>
+<audio id="audio-nocontrol-tabindex-none"></audio>
+<audio id="audio-control-tabindex-invalid" tabindex="foo" controls></audio>
+<audio id="audio-control-tabindex-2" tabindex="2" controls></audio>
+
+<video id="video-control-tabindex-none" controls></video>
+<video id="video-nocontrol-tabindex-none"></video>
+<video id="video-control-tabindex-invalid" tabindex="bar" controls></video>
+<video id="video-control-tabindex-3" tabindex="3" controls></video>
+
+<details id="details-tabindex-none">
+  <summary>details tabindex-none title</summary>
+  details tabindex-none content
+</details>
+<details id="details-tabindex-neg" tabindex="-1">
+  <summary>details tabindex-neg title</summary>
+  details tabindex-neg content
+</details>

--- a/test/unit/node.test.js
+++ b/test/unit/node.test.js
@@ -1,8 +1,9 @@
-const { isFocusable, isTabbable } = require('../../src/index.js');
+const { isFocusable, isTabbable, getTabIndex } = require('../../src/index.js');
 
 describe('tabbable unit tests', () => {
   it('should throw with no input node', () => {
     expect(() => isFocusable()).toThrow();
     expect(() => isTabbable()).toThrow();
+    expect(() => getTabIndex()).toThrow();
   });
 });

--- a/test/unit/unit.test.js
+++ b/test/unit/unit.test.js
@@ -1,5 +1,5 @@
 const fixtures = require('../fixtures/fixtures');
-const { tabbable, focusable } = require('../../src/index.js');
+const { tabbable, focusable, getTabIndex } = require('../../src/index.js');
 
 const getElementIds = function (elements) {
   return elements.map((el) => el.id);
@@ -138,6 +138,42 @@ describe('unit tests', () => {
         const elements = focusable(container, options);
 
         expectElementsInOrder(getElementIds(elements), []);
+      });
+    });
+  });
+
+  describe('getTabIndex', () => {
+    describe('tabindex example', () => {
+      let container;
+
+      beforeEach(() => {
+        container = document.createElement('div');
+        container.innerHTML = fixtures.tabindex;
+        document.body.append(container);
+      });
+
+      it('correctly identifies tab index of elements', () => {
+        const results = Array.from(container.children).map((child) => [
+          child.id,
+          getTabIndex(child),
+        ]);
+
+        expect(results).toEqual([
+          ['anchor-tabindex-none', 0],
+          ['btn-tabindex-1', 1],
+          ['contenteditable-tabindex-none', 0],
+          ['contenteditable-tabindex-neg', -1],
+          ['audio-control-tabindex-none', 0],
+          ['audio-nocontrol-tabindex-none', 0],
+          ['audio-control-tabindex-invalid', 0],
+          ['audio-control-tabindex-2', 2],
+          ['video-control-tabindex-none', 0],
+          ['video-nocontrol-tabindex-none', 0],
+          ['video-control-tabindex-invalid', 0],
+          ['video-control-tabindex-3', 3],
+          ['details-tabindex-none', 0],
+          ['details-tabindex-neg', -1],
+        ]);
       });
     });
   });


### PR DESCRIPTION
This is needed for https://github.com/focus-trap/focus-trap/pull/974 which will add support for positive tabindexes in focus-trap.

Also updates the docs/typings to make them more consistent and fix some broken links.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
