### PR TITLE
feat: use native `:not([inert] *)` selector to filter out elements in inert subtrees

### DIFF
--- a/.changeset/nice-days-attack.md
+++ b/.changeset/nice-days-attack.md
@@ -1,0 +1,7 @@
+---
+'tabbable': minor
+---
+
+Enable CSS selector matching for whether an element is in an inert subtree (`[inert] *`).
+
+This was previously disabled due to JSDOM's CSS selector engine being incompatible with this selector, and throwing all the results off. Instead, tabbable would perform manual checks for an element being in an inert subtree. The CSS selector issue appears to have been fixed in recent JSDOM versions (at least 26), so this version reintroduces the selector fast path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -162,7 +161,6 @@
       "integrity": "sha512-fcdRcWahONYo+JRnJg1/AekOacGvKx12Gu0qXJXFi2WBqQA1i7+O5PaxRB7kxE/Op94dExnCiiar6T09pvdHpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
@@ -1769,7 +1767,6 @@
       "integrity": "sha512-S36mOoi1Sb6Fz98fBfE+UZSpYw5mJm0NUHtIKrOuNcqeFauy1J6dIvXm2KRVKobOSaGq4t/hBXdN4HGU3wL9Wg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.28.5",
         "@babel/helper-compilation-targets": "^7.27.2",
@@ -2375,7 +2372,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2399,7 +2395,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4142,7 +4137,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4214,7 +4208,6 @@
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -4333,7 +4326,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4449,7 +4441,6 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -5099,7 +5090,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5727,7 +5717,6 @@
       "integrity": "sha512-z8jt+EdS61AMw22nSfoNJAZ0vrtmhPRVi6ghL3rCeRZI8cdNYFiV5xeV3HbE7rlZZNmGH8BVccwWt8/ED0QOHA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "find-up": "^5.0.0"
       },
@@ -6283,7 +6272,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -7075,7 +7063,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cypress/request": "^3.0.9",
         "@cypress/xvfb": "^1.2.4",
@@ -8193,7 +8180,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8417,7 +8403,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11137,7 +11122,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -12383,7 +12367,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -13262,9 +13245,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
-      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -14823,7 +14806,6 @@
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -15030,7 +15012,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -16837,7 +16818,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16964,7 +16944,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.2.2"
       },
@@ -17269,7 +17248,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -98,8 +98,5 @@
     "typescript": "^5.9.3",
     "watchify": "^4.0.0",
     "webpack": "^5.103.0"
-  },
-  "overrides": {
-    "nwsapi": "2.2.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -50,10 +50,11 @@ const isInert = function (node, lookUp = true) {
     inert ||
     (lookUp &&
       node &&
-      // closest is only defined on Element, but does not exist on shadow roots,
-      // so we fall back to manual lookups upward in case it is not defined.
-      ((typeof node.closest === 'function' && node.closest('[inert]')) ||
-        isInert(node.parentNode)));
+      // closest does not exist on shadow roots, so we fall back to a manual
+      // lookup upward, in case it is not defined.
+      (typeof node.closest === 'function'
+        ? node.closest('[inert]')
+        : isInert(node.parentNode)));
 
   return result;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,17 @@
 // NOTE: separate `:not()` selectors has broader browser support than the newer
 //  `:not([inert], [inert] *)` (Feb 2023)
-// CAREFUL: JSDom does not support `:not([inert] *)` as a selector; using it causes
-//  the entire query to fail, resulting in no nodes found, which will break a lot
-//  of things... so we have to rely on JS to identify nodes inside an inert container
 const candidateSelectors = [
-  'input:not([inert])',
-  'select:not([inert])',
-  'textarea:not([inert])',
-  'a[href]:not([inert])',
-  'button:not([inert])',
-  '[tabindex]:not(slot):not([inert])',
-  'audio[controls]:not([inert])',
-  'video[controls]:not([inert])',
-  '[contenteditable]:not([contenteditable="false"]):not([inert])',
-  'details>summary:first-of-type:not([inert])',
-  'details:not([inert])',
+  'input:not([inert]):not([inert] *)',
+  'select:not([inert]):not([inert] *)',
+  'textarea:not([inert]):not([inert] *)',
+  'a[href]:not([inert]):not([inert] *)',
+  'button:not([inert]):not([inert] *)',
+  '[tabindex]:not(slot):not([inert]):not([inert] *)',
+  'audio[controls]:not([inert]):not([inert] *)',
+  'video[controls]:not([inert]):not([inert] *)',
+  '[contenteditable]:not([contenteditable="false"]):not([inert]):not([inert] *)',
+  'details>summary:first-of-type:not([inert]):not([inert] *)',
+  'details:not([inert]):not([inert] *)',
 ];
 const candidateSelector = /* #__PURE__ */ candidateSelectors.join(',');
 
@@ -52,6 +49,7 @@ const isInert = function (node, lookUp = true) {
   // CAREFUL: JSDom does not appear to support certain selectors like `:not([inert] *)`
   //  so it likely would not support `:is([inert] *)` either...
   const result = inert || (lookUp && node && isInert(node.parentNode)); // recursive
+  // const result = inert || (lookUp && node && isInert(node.closest('[inert]'))); // recursive
 
   return result;
 };
@@ -77,7 +75,7 @@ const isContentEditable = function (node) {
  */
 const getCandidates = function (el, includeContainer, filter) {
   // even if `includeContainer=false`, we still have to check it for inertness because
-  //  if it's inert, all its children are inert
+  //  if it's inert (either by itself or via its parent), then all its children are inert
   if (isInert(el)) {
     return [];
   }
@@ -561,10 +559,6 @@ const isDisabledFromFieldset = function (node) {
 const isNodeMatchingSelectorFocusable = function (options, node) {
   if (
     node.disabled ||
-    // we must do an inert look up to filter out any elements inside an inert ancestor
-    //  because we're limited in the type of selectors we can use in JSDom (see related
-    //  note related to `candidateSelectors`)
-    isInert(node) ||
     isHiddenInput(node) ||
     isHidden(node, options) ||
     // For a details element with a summary, the summary element gets the focus

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ const getRootNode =
 
 /**
  * Determines if a node is inert or in an inert ancestor.
- * @param {Element} [node]
+ * @param {Node} [node]
  * @param {boolean} [lookUp] If true and `node` is not inert, looks up at ancestors to
  *  see if any of them are inert. If false, only `node` itself is considered.
  * @returns {boolean} True if inert itself or by way of being in an inert ancestor.
@@ -46,7 +46,14 @@ const isInert = function (node, lookUp = true) {
   // NOTE: this could also be handled with `node.matches('[inert], :is([inert] *)')`
   //  if it weren't for `matches()` not being a function on shadow roots; the following
   //  code works for any kind of node
-  const result = inert || (lookUp && node && node.closest('[inert]'));
+  const result =
+    inert ||
+    (lookUp &&
+      node &&
+      // closest is only defined on Element, but does not exist on shadow roots,
+      // so we fall back to manual lookups upward in case it is not defined.
+      ((typeof node.closest === 'function' && node.closest('[inert]')) ||
+        isInert(node.parentNode)));
 
   return result;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -46,10 +46,7 @@ const isInert = function (node, lookUp = true) {
   // NOTE: this could also be handled with `node.matches('[inert], :is([inert] *)')`
   //  if it weren't for `matches()` not being a function on shadow roots; the following
   //  code works for any kind of node
-  // CAREFUL: JSDom does not appear to support certain selectors like `:not([inert] *)`
-  //  so it likely would not support `:is([inert] *)` either...
-  const result = inert || (lookUp && node && isInert(node.parentNode)); // recursive
-  // const result = inert || (lookUp && node && isInert(node.closest('[inert]'))); // recursive
+  const result = inert || (lookUp && node && node.closest('[inert]'));
 
   return result;
 };
@@ -691,7 +688,7 @@ const isTabbable = function (node, options) {
 };
 
 const focusableCandidateSelector = /* #__PURE__ */ candidateSelectors
-  .concat('iframe')
+  .concat('iframe:not([inert]):not([inert] *)')
   .join(',');
 
 const isFocusable = function (node, options) {

--- a/test/e2e/isFocusable.cy.js
+++ b/test/e2e/isFocusable.cy.js
@@ -3,6 +3,7 @@ import {
   setupTestDocument,
   getFixtures,
   removeAllChildNodes,
+  getIdsFromElementsArray,
 } from './e2e.helpers';
 const { getByTestId, getByText } = require('@testing-library/dom');
 
@@ -428,9 +429,9 @@ describe('isFocusable', () => {
         container.innerHTML = fixtures.inert;
         document.body.append(container);
 
-        for (const child of container.children) {
-          expect(isFocusable(child)).to.eql(false);
-        }
+        const focusables = Array.from(container.children).filter(isFocusable);
+
+        expect(getIdsFromElementsArray(focusables)).to.eql([]);
       });
 
       it('returns false for any element inside an inert parent', () => {
@@ -439,9 +440,9 @@ describe('isFocusable', () => {
         container.inert = true;
         document.body.append(container);
 
-        for (const child of container.children) {
-          expect(isFocusable(child), child.id).to.eql(false);
-        }
+        const focusables = Array.from(container.children).filter(isFocusable);
+
+        expect(getIdsFromElementsArray(focusables)).to.eql([]);
       });
 
       it('returns false for any element inside an inert ancestor', () => {
@@ -453,9 +454,9 @@ describe('isFocusable', () => {
         parent.appendChild(container);
         document.body.append(parent);
 
-        for (const child of container.children) {
-          expect(isFocusable(child), child.id).to.eql(false);
-        }
+        const focusables = Array.from(container.children).filter(isFocusable);
+
+        expect(getIdsFromElementsArray(focusables)).to.eql([]);
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your contribution! 🎉

Please be sure to go over the PR CHECKLIST below before posting your PR to make sure we all think of "everything". :)
-->

Closes #997 

Hi @stefcameron 👋 While working on #1818 and tweaking the code, I noticed that JSDOM has started supporting `:not([inert] *)` again*.  

Edit: aha, you also spotted that in https://github.com/focus-trap/tabbable/issues/997#issuecomment-3592077879 😅 

So in this PR I am reintroducing this selector, which should make the tabbable checks a bit more efficient, and the code a bit cleaner (there's one less check to do manually). The unit/component tests (with JSDOM 26.1.0) pass without change.

*It is a bit unclear to me whether the reason is `nwsapi` fixing its parsing, or the fact that JSDOM is using a different CSS selector engine. I can bisect JSDOM versions a bit, to see which one it is.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Web APIs introduced have __deep__ browser coverage, including Safari (often very late to adopt new APIs).
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored a fast-path CSS selector check so elements inside inert subtrees are correctly excluded, improving focusability detection and compatibility with newer JSDOM versions.

* **Chores**
  * Simplified inert-handling logic for more robust element detection and removed an unnecessary package override.

* **Tests**
  * Streamlined end-to-end tests to use a helper-based ID comparison for verifying focusable elements.

* **Documentation**
  * Added a minor release note describing inert subtree selector behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->