### PR TITLE
Support `<area href>` image map hotspots

### DIFF
--- a/.changeset/tabbable-area-href.md
+++ b/.changeset/tabbable-area-href.md
@@ -1,0 +1,5 @@
+---
+'tabbable': minor
+---
+
+Add support for `<area>` elements with an `href` attribute (image map hotspots),

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The following are considered tabbable:
 - `<select>` elements
 - `<textarea>` elements
 - `<a>` elements with an `href` attribute
+- `<area>` elements with an `href` attribute (inside a `<map>` referenced by a rendered image)
 - `<audio>` and `<video>` elements with `controls` attributes
 - the first `<summary>` element directly under a `<details>` element
 - `<details>` element without a `<summary>` element

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const candidateSelectors = [
   'select:not([inert]):not([inert] *)',
   'textarea:not([inert]):not([inert] *)',
   'a[href]:not([inert]):not([inert] *)',
+  'area[href]:not([inert]):not([inert] *)',
   'button:not([inert]):not([inert] *)',
   '[tabindex]:not(slot):not([inert]):not([inert] *)',
   'audio[controls]:not([inert]):not([inert] *)',

--- a/test/e2e/focusable.cy.js
+++ b/test/e2e/focusable.cy.js
@@ -333,6 +333,20 @@ describe('focusable', () => {
       );
     });
 
+    it('correctly identifies focusable elements in the "area" example', () => {
+      const expectedFocusableIds = ['area-href', 'area-negative-tabindex'];
+
+      const container = document.createElement('div');
+      container.innerHTML = fixtures.area;
+      document.body.append(container);
+
+      const focusableElements = focusable(container);
+
+      expect(getIdsFromElementsArray(focusableElements)).to.eql(
+        expectedFocusableIds
+      );
+    });
+
     it('correctly identifies focusable elements in the "radio" example', () => {
       const expectedFocusableIds = [
         'form1-radioA',

--- a/test/e2e/tabbable.cy.js
+++ b/test/e2e/tabbable.cy.js
@@ -329,6 +329,20 @@ describe('tabbable', () => {
       );
     });
 
+    it('correctly identifies tabbable elements in the "area" example', () => {
+      const expectedTabbableIds = ['area-href'];
+
+      const container = document.createElement('div');
+      container.innerHTML = fixtures.area;
+      document.body.append(container);
+
+      const tabbableElements = tabbable(container);
+
+      expect(getIdsFromElementsArray(tabbableElements)).to.eql(
+        expectedTabbableIds
+      );
+    });
+
     it('correctly identifies tabbable elements in the "radio" example', () => {
       const expectedTabbableIds = [
         'form1-radioA',

--- a/test/fixtures/area.html
+++ b/test/fixtures/area.html
@@ -1,0 +1,29 @@
+<img
+  id="area-image"
+  width="320"
+  height="160"
+  usemap="#area-map"
+  alt="image map"
+  src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTYwIj48cmVjdCB3aWR0aD0iMzIwIiBoZWlnaHQ9IjE2MCIgZmlsbD0iI2Y0ZjRmNCIvPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDYiIGhlaWdodD0iMTYwIiBmaWxsPSIjN2FhNmZmIi8+PGNpcmNsZSBjeD0iMTYwIiBjeT0iODAiIHI9IjM1IiBmaWxsPSIjYmRiZGJkIi8+PHJlY3QgeD0iMjE0IiB5PSIwIiB3aWR0aD0iMTA2IiBoZWlnaHQ9IjE2MCIgZmlsbD0iI2ZmZDI3YSIvPjx0ZXh0IHg9IjUzIiB5PSI4NSIgZm9udC1zaXplPSIxMyIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZmlsbD0iIzAwMCI+aHJlZjwvdGV4dD48dGV4dCB4PSIxNjAiIHk9Ijg0IiBmb250LXNpemU9IjEyIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjMDAwIj5ubyBocmVmPC90ZXh0Pjx0ZXh0IHg9IjI2NyIgeT0iNzgiIGZvbnQtc2l6ZT0iMTEiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGZpbGw9IiMwMDAiPnRhYmluZGV4PC90ZXh0Pjx0ZXh0IHg9IjI2NyIgeT0iOTIiIGZvbnQtc2l6ZT0iMTEiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGZpbGw9IiMwMDAiPi0xPC90ZXh0Pjwvc3ZnPg=="
+/>
+<map name="area-map">
+  <!-- has href -> tabbable + focusable -->
+  <area
+    id="area-href"
+    shape="rect"
+    coords="0,0,106,160"
+    href="#href"
+    alt="href"
+  />
+  <!-- no href -> neither tabbable nor focusable (excluded by the selector) -->
+  <area id="area-no-href" shape="circle" coords="160,80,35" alt="no href" />
+  <!-- href but negative tabindex -> focusable but NOT tabbable -->
+  <area
+    id="area-negative-tabindex"
+    shape="rect"
+    coords="214,0,320,160"
+    href="#negative"
+    tabindex="-1"
+    alt="negative tabindex"
+  />
+</map>

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -17,6 +17,7 @@ module.exports = {
     'utf8'
   ),
   svg: fs.readFileSync(path.join(__dirname, 'svg.html'), 'utf8'),
+  area: fs.readFileSync(path.join(__dirname, 'area.html'), 'utf8'),
   radio: fs.readFileSync(path.join(__dirname, 'radio.html'), 'utf8'),
   details: fs.readFileSync(path.join(__dirname, 'details.html'), 'utf8'),
   'shadow-dom': fs.readFileSync(


### PR DESCRIPTION
<!--
Thank you for your contribution! 🎉

Please be sure to go over the PR CHECKLIST below before posting your PR to make sure we all think of "everything". :)
-->

Adds `<area>` elements with an `href` attribute to the set of elements tabbable considers tabbable/focusable.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Web APIs introduced have __deep__ browser coverage, including Safari (often very late to adopt new APIs).
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for `<area>` elements with `href` attributes (image map hotspots) to be recognized as tabbable and focusable elements.

* **Documentation**
  * Updated documentation to include `<area>` elements in the list of recognized tabbable elements.

* **Tests**
  * Added test coverage for `<area>` element functionality across tabbable and focusable scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->