### PR TITLE
Log `tabbable`/`focusable` state in debug page

### DIFF
--- a/test/debug.js
+++ b/test/debug.js
@@ -2,7 +2,8 @@
 
 const { ...testCases } = require('./fixtures/fixtures.js');
 const { appendHTMLWithShadowRoots } = require('./shadow-root-utils');
-global.tabbable = require('../src/index.js');
+const { tabbable, focusable, getTabIndex } =
+  (global.tabbable = require('../src/index.js'));
 
 let root;
 let content;
@@ -51,3 +52,36 @@ document.body.addEventListener('focusin', onFocusIn);
 const styleTag = document.createElement('style');
 styleTag.innerHTML = ':focus { outline: 5px solid #b603f6; }';
 document.body.appendChild(styleTag);
+
+// Log out tabbable/focusable elements on the page on startup
+const allTabbable = tabbable(document.body);
+const allFocusable = focusable(document.body);
+const focusableNotTabbable = allFocusable.filter(
+  (element) => !allTabbable.includes(element)
+);
+
+/* eslint-disable no-console */
+console.groupCollapsed(
+  'Tabbable elements on the page (' + allTabbable.length + ')'
+);
+allTabbable.forEach((element) =>
+  console.log('tabindex ' + getTabIndex(element) + ':', element)
+);
+console.groupEnd();
+
+console.groupCollapsed(
+  'Focusable elements on the page (' + allFocusable.length + ')'
+);
+allFocusable.forEach((element) =>
+  console.log('tabindex ' + getTabIndex(element) + ':', element)
+);
+console.groupEnd();
+
+console.groupCollapsed(
+  'Focusable but not tabbable (' + focusableNotTabbable.length + ')'
+);
+focusableNotTabbable.forEach((element) =>
+  console.log('tabindex ' + getTabIndex(element) + ':', element)
+);
+console.groupEnd();
+/* eslint-enable no-console */


### PR DESCRIPTION
<!--
Thank you for your contribution! 🎉

Please be sure to go over the PR CHECKLIST below before posting your PR to make sure we all think of "everything". :)
-->

Was useful to me while debugging #2088 and #2087, might be useful for others.  

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Source changes maintain stated browser compatibility.
- Web APIs introduced have __deep__ browser coverage, including Safari (often very late to adopt new APIs).
- Issue being fixed is referenced.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved debugging output to show tabbable and focusable elements at startup, including their tab index values.
  * Added clearer grouped console logging for focus-related inspection, making navigation issues easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->